### PR TITLE
BugFix: hook not executed when only config is updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,16 @@ This command will:
 
 ### Hooks
 
-You can define `post_install` and `post_purge` hooks in your module's `init.lua` to run arbitrary commands after the module has been installed or purged.
+You can define custom hooks in your module's `init.lua` file to run specific commands at different stages of the module's lifecycle.
 
+#### Available Hooks
+
+- **`post_install`**: Runs after the specified packages have been installed via `brew`.
+- **`post_purge`**: Runs after the specified packages have been removed via `brew`.
+- **`post_link`**: Runs after configuration files have been linked.
+- **`post_unlink`**: Runs after configuration files have been unlinked.
+
+#### Basic Hook Definition
 ```lua
 return {
   brew = { "gh" },
@@ -237,7 +245,9 @@ return {
 }
 ```
 
-You can also define multi-line hooks:
+#### Multi-Line Hook Definition
+
+You can also define multi-line hooks using Lua's multi-line string syntax.
 
 ```lua
 return {

--- a/dot.lua
+++ b/dot.lua
@@ -499,11 +499,20 @@ local function process_module(module_name, options)
   local config_changed = handle_config_symlink(config, module_dir, options)
 
   -- Run post_install or post_purge hooks
-  if dependencies_changed or config_changed or options.hooks_mode then
+  if dependencies_changed or options.hooks_mode then
     if options.purge_mode and config.post_purge then
       run_hook(config.post_purge, "post-purge")
     elseif not options.purge_mode and config.post_install then
       run_hook(config.post_install, "post-install")
+    end
+  end
+
+  -- Run post_config or post_config_purge hooks
+  if config_changed or options.hooks_mode then
+    if options.purge_mode and config.post_config_purge then
+      run_hook(config.post_config_purge, "post-config-purge")
+    elseif not options.purge_mode and config.post_config then
+      run_hook(config.post_config, "post-config")
     end
   end
 

--- a/dot.lua
+++ b/dot.lua
@@ -507,12 +507,12 @@ local function process_module(module_name, options)
     end
   end
 
-  -- Run post_config or post_config_purge hooks
+  -- Run post_link or post_unlink hooks
   if config_changed or options.hooks_mode then
-    if options.purge_mode and config.post_config_purge then
-      run_hook(config.post_config_purge, "post-config-purge")
-    elseif not options.purge_mode and config.post_config then
-      run_hook(config.post_config, "post-config")
+    if options.purge_mode and config.post_unlink then
+      run_hook(config.post_unlink, "post-unlink")
+    elseif not options.purge_mode and config.post_link then
+      run_hook(config.post_link, "post-link")
     end
   end
 

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -411,6 +411,8 @@ return {
   },
   post_install = "touch %s/.hooks_post_install_ran",
   post_purge = "touch %s/.hooks_post_purge_ran",
+  post_link = "touch %s/.hooks_post_link_ran",
+  post_unlink = "touch %s/.hooks_post_unlink_ran",
 }
 ]],
         home_dir,
@@ -430,6 +432,11 @@ return {
     print("Checking for hook_install at:", hook_install)
     assert.is_true(path_exists(hook_install), "Post-install hook did not run")
 
+    -- Check if post_link hook ran
+    local hook_link = pl_path.join(home_dir, ".hooks_post_link_ran")
+    print("Checking for hook_link at:", hook_link)
+    assert.is_true(path_exists(hook_link), "Post-link hook did not run")
+
     -- Run dot.lua with --purge option for 'dummy_app'
     assert.is_true(run_dot "--purge dummy_app")
 
@@ -437,6 +444,11 @@ return {
     local hook_purge = pl_path.join(home_dir, ".hooks_post_purge_ran")
     print("Checking for hook_purge at:", hook_purge)
     assert.is_true(path_exists(hook_purge), "Post-purge hook did not run")
+
+    -- Check if post_unlink hook ran
+    local hook_unlink = pl_path.join(home_dir, ".hooks_post_unlink_ran")
+    print("Checking for hook_unlink at:", hook_unlink)
+    assert.is_true(path_exists(hook_unlink), "Post-unlink hook did not run")
   end)
 
   it("should handle multiple configs in a module", function()


### PR DESCRIPTION
This fix adjusts the logic to ensure that hooks are correctly called, even for modules containing only configuration files. 

Now, all modules, whether they contain brew package or only configurations, will have their hooks called.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration symlink handling to track changes more effectively.
	- Expanded conditions for executing post-install and post-unlink hooks based on configuration changes.
	- Improved documentation on hooks, including detailed descriptions and examples for better user understanding.

- **Bug Fixes**
	- Improved return values for functions to ensure consistent boolean outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->