### PR TITLE
dot 1.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "stylua.targetReleaseVersion": "latest"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "stylua.targetReleaseVersion": "latest"
-}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 - [Examples](#examples)
 
 ## Installation
-
 ```bash
 $ brew install pablopunk/brew/dot
 ```
@@ -330,3 +329,4 @@ $ dot -h                  # Show help
 ## Examples
 
 - [pablopunk/dotfiles](https://github.com/pablopunk/dotfiles): my own dotfiles, using `dot` to manage them.
+

--- a/README.md
+++ b/README.md
@@ -293,9 +293,14 @@ $ dot app -e              # Export app preferences to plist
 $ dot app -i              # Import app preferences from plist
 ```
 
+### Hook Options
+```bash
+$ dot --postinstall       # Run postinstall hooks even if dependencies haven't changed
+$ dot --postlink          # Run postlink hooks even if symlinks haven't changed
+```
+
 ### Other Options
 ```bash
-$ dot --hooks             # Run hooks even if nothing changed
 $ dot --remove-profile    # Remove the last used profile
 $ dot --version           # Show version
 $ dot -h                  # Show help

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - [macOS Preferences (defaults)](#macos-preferences-defaults)
   - [OS Restrictions](#os-restrictions)
   - [Profiles](#profiles)
-  - [Hooks](#hooks)
+  - [Hooks](#hooks]
 - [Command-Line Options](#command-line-options)
 - [Examples](#examples)
 
@@ -36,22 +36,18 @@ $ brew install pablopunk/brew/dot
 $ cd /path/to/dotfiles
 $ tree
 
-profiles/
-├── work.lua
-├── personal.lua
-├── linux-server.lua
-modules/
-├── neovim/
-│   ├── dot.lua
-│   └── config/
-├── zsh/
-│   ├── dot.lua
-│   └── zshrc
-└── apps/
-    ├── work/
-    │   └── dot.lua
-    └── personal/
-        └── dot.lua
+profiles.lua
+neovim/
+├── dot.lua
+└── config/
+zsh/
+├── dot.lua
+└── zshrc
+apps/
+├── work/
+│   └── dot.lua
+└── personal/
+    └── dot.lua
 
 $ dot          # Link all dotfiles and install dependencies
 $ dot neovim   # Only process the 'neovim' module
@@ -62,14 +58,14 @@ $ dot work     # Only process the 'work' profile
 
 ### Modules
 
-Each module under the `modules/` folder needs to have a `dot.lua` file. **Modules can be nested** - you can have directories within the `modules/` folder, and each can contain its own `dot.lua` to define configurations and dependencies.
+Any subdirectory containing a `dot.lua` file is considered a module. **Modules can be nested** - you can have directories within directories, and each can contain its own `dot.lua` to define configurations and dependencies.
 
 #### `dot.lua`
 
 Example for neovim:
 
 ```lua
--- modules/neovim/dot.lua
+-- neovim/dot.lua
 return {
   install = {
     brew = "brew install neovim ripgrep",
@@ -86,7 +82,7 @@ return {
 The `install` system dynamically detects available package managers and uses the first one found. You can specify multiple package managers, and `dot` will use the first available one.
 
 ```lua
--- modules/apps/dot.lua
+-- apps/dot.lua
 return {
   install = {
     brew = "brew install whatsapp spotify slack vscode",
@@ -103,7 +99,7 @@ In this example, if `brew` is available, it will use that. If not, it will try `
 The `link` system creates symlinks from your dotfiles to their destinations. Use the new key-value format:
 
 ```lua
--- modules/multi-config/dot.lua
+-- cursor/dot.lua
 return {
   install = {
     brew = "brew install cursor"
@@ -117,8 +113,8 @@ return {
 
 This creates symlinks:
 ```bash
-~/Library/Application Support/Cursor/User/settings.json → ~/dotfiles/modules/multi-config/config/settings.json
-~/Library/Application Support/Cursor/User/keybindings.json → ~/dotfiles/modules/multi-config/config/keybindings.json
+~/Library/Application Support/Cursor/User/settings.json → ~/dotfiles/cursor/config/settings.json
+~/Library/Application Support/Cursor/User/keybindings.json → ~/dotfiles/cursor/config/keybindings.json
 ```
 
 ### macOS Preferences (defaults)
@@ -126,7 +122,7 @@ This creates symlinks:
 Manage macOS application preferences using the `defaults` field:
 
 ```lua
--- modules/swiftshift/dot.lua
+-- swiftshift/dot.lua
 return {
   defaults = {
     ["com.pablopunk.Swift-Shift"] = "./defaults/SwiftShift.xml"
@@ -168,7 +164,7 @@ $ dot swiftshift --defaults-import  # or -i
 Restrict modules to specific operating systems:
 
 ```lua
--- modules/macos-only/dot.lua
+-- macos-only/dot.lua
 return {
   os = { "mac" },  -- Only runs on macOS
   install = {
@@ -187,26 +183,31 @@ Supported OS values:
 
 ### Profiles
 
-Profiles let you manage different setups for different machines:
+Profiles let you manage different setups for different machines. Create a single `profiles.lua` file:
 
 ```lua
--- profiles/personal.lua
+-- profiles.lua
 return {
-  modules = {
-    "*",           -- Include all modules
-    "!apps/work"   -- Exclude work apps
-  }
-}
-```
-
-```lua
--- profiles/work.lua
-return {
-  modules = {
-    "apps/work",
-    "slack",
-    "neovim",
-    "zsh"
+  personal = {
+    modules = {
+      "*",           -- Include all modules
+      "!apps/work"   -- Exclude work apps
+    }
+  },
+  work = {
+    modules = {
+      "apps/work",
+      "slack",
+      "neovim",
+      "zsh"
+    }
+  },
+  linux_server = {
+    modules = {
+      "zsh",
+      "neovim",
+      "tmux"
+    }
   }
 }
 ```
@@ -285,8 +286,6 @@ Remove symlinks but keep config files:
 ```bash
 $ dot --unlink neovim
 ```
-
-
 
 ### Defaults Management
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ brew install pablopunk/brew/dot
 $ cd /path/to/dotfiles
 $ tree
 
-profiles.lua
+profiles.lua # work, personal, server...
 neovim/
 ├── dot.lua
 └── config/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ The curl installer will:
 - Download and install the `dot` tool
 - Add it to your PATH
 
+**To update the tool later:**
+```bash
+dot --update
+```
+
 ## Quick Start
 
 <img src="https://github.com/user-attachments/assets/8c235cb8-d6c5-4f9c-88db-db1a04e914e4" width="600px" />

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Example for neovim:
 return {
   install = {
     brew = "brew install neovim ripgrep",
-    apt = "apt install neovim ripgrep"
+    apt = "sudo apt install -y neovim ripgrep"
   },
   link = {
-    ["./config"] = "~/.config/nvim"
+    ["./config"] = "~/.config/nvim" -- link the whole directory or just one file, your choice
   }
 }
 ```
@@ -86,7 +86,7 @@ The `install` system dynamically detects available package managers and uses the
 return {
   install = {
     brew = "brew install whatsapp spotify slack vscode",
-    apt = "apt install vim git curl",
+    apt = "sudo apt install -y vim git curl",
     yum = "yum install vim git curl"
   }
 }
@@ -189,25 +189,19 @@ Profiles let you manage different setups for different machines. Create a single
 -- profiles.lua
 return {
   personal = {
-    modules = {
-      "*",           -- Include all modules
-      "!apps/work"   -- Exclude work apps
-    }
+    "*",           -- Include all modules
+    "!apps/work"   -- Exclude work apps
   },
   work = {
-    modules = {
-      "apps/work",
-      "slack",
-      "neovim",
-      "zsh"
-    }
+    "apps/work",
+    "slack",
+    "neovim",
+    "zsh"
   },
   linux_server = {
-    modules = {
-      "zsh",
-      "neovim",
-      "tmux"
-    }
+    "zsh",
+    "neovim",
+    "tmux"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,9 +23,22 @@
 - [Examples](#examples)
 
 ## Installation
+
+**Option 1: Using curl (installs Lua and dot)**
 ```bash
-$ brew install pablopunk/brew/dot
+curl -fsSL https://raw.githubusercontent.com/pablopunk/dot/main/install.sh | bash
 ```
+
+**Option 2: Using Homebrew**
+```bash
+brew install pablopunk/brew/dot
+```
+
+The curl installer will:
+- Detect your OS (macOS, Linux)
+- Install Lua if not present
+- Download and install the `dot` tool
+- Add it to your PATH
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ $ dot --remove-profile
 
 ### Hooks
 
-Run commands after installation, linking, or purging:
+Run commands after installation or linking:
 
 ```lua
 return {
@@ -263,7 +263,6 @@ return {
 Available hooks:
 - `postinstall`: Runs after dependencies are installed
 - `postlink`: Runs after files are linked
-- `postpurge`: Runs after module is purged
 
 ## Command-Line Options
 
@@ -287,11 +286,7 @@ Remove symlinks but keep config files:
 $ dot --unlink neovim
 ```
 
-### Purge Mode
-Uninstall dependencies and remove configurations:
-```bash
-$ dot --purge neovim
-```
+
 
 ### Defaults Management
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ profiles/
 ├── linux-server.lua
 modules/
 ├── neovim/
-│   ├── init.lua
+│   ├── dot.lua
 │   └── config/
 ├── zsh/
-│   ├── init.lua
+│   ├── dot.lua
 │   └── zshrc
 └── apps/
     ├── work/
-    │   └── init.lua
+    │   └── dot.lua
     └── personal/
-        └── init.lua
+        └── dot.lua
 
 $ dot          # Link all dotfiles and install dependencies
 $ dot neovim   # Only process the 'neovim' module
@@ -66,14 +66,14 @@ $ dot work     # Only process the 'work' profile
 
 ### Modules
 
-Each module under the `modules/` folder needs to have at least an `init.lua`. If not, it will be ignored. **Modules can be recursive**, meaning you can have nested directories within the `modules/` folder, and each can contain its own `init.lua` to define configurations and dependencies.
+Each module under the `modules/` folder needs to have at least a `dot.lua`. If not, it will be ignored. **Modules can be recursive**, meaning you can have nested directories within the `modules/` folder, and each can contain its own `dot.lua` to define configurations and dependencies.
 
-#### `init.lua`
+#### `dot.lua`
 
 Example for neovim:
 
 ```lua
--- modules/neovim/init.lua
+-- modules/neovim/dot.lua
 return {
   brew = {
     { name = "neovim", options = "--HEAD" },
@@ -93,7 +93,7 @@ return {
 As you can see, you can declare dependencies as [Homebrew](https://brew.sh) packages, which makes it possible to also use `dot` to install GUI apps (Homebrew casks). You can create a module without any config to use it as an installer for your apps:
 
 ```lua
--- modules/apps/init.lua
+-- modules/apps/dot.lua
 return {
   brew = { "whatsapp", "spotify", "slack", "vscode" }
 }
@@ -101,12 +101,12 @@ return {
 
 #### Wget
 
-`dot` now supports downloading files using `wget`. This can be useful for fetching binaries or other resources that are not available through Homebrew. You can specify a `wget` configuration in your module's `init.lua` file.
+`dot` now supports downloading files using `wget`. This can be useful for fetching binaries or other resources that are not available through Homebrew. You can specify a `wget` configuration in your module's `dot.lua` file.
 
 Example:
 
 ```lua
--- modules/apps/init.lua
+-- modules/apps/dot.lua
 return {
   wget = {
     {
@@ -137,7 +137,7 @@ The config will be linked to the home folder with a soft link. In this case:
 You can also specify multiple configurations for a single module:
 
 ```lua
--- modules/multi-config/init.lua
+-- modules/multi-config/dot.lua
 return {
   brew = { "cursor" },
   config = {
@@ -161,10 +161,10 @@ This will create two symlinks:
 ```
 ### OS Restrictions
 
-You can restrict modules to specific operating systems using the `os` field in your module's `init.lua`:
+You can restrict modules to specific operating systems using the `os` field in your module's `dot.lua`:
 
 ```lua
--- modules/macos-only/init.lua
+-- modules/macos-only/dot.lua
 return {
   os = { "mac" },  -- This module will only run on macOS
   brew = { "mac-specific-app" },
@@ -201,7 +201,7 @@ You can manage macOS application preferences using the `defaults` field in your 
 Example:
 
 ```lua
--- modules/swiftshift/init.lua
+-- modules/swiftshift/dot.lua
 return {
   defaults = {
     {
@@ -349,7 +349,7 @@ $ dot --purge neovim
 
 This command will:
 
-- Uninstall the Homebrew dependencies listed in the module's `init.lua`.
+- Uninstall the Homebrew dependencies listed in the module's `dot.lua`.
 - Remove the symlink or config file/directory specified in `config.output`.
 - Run any `post_purge` hooks if defined in the module.
 
@@ -358,7 +358,7 @@ This command will:
 
 ### Hooks
 
-You can define `post_install` and `post_purge` hooks in your module's `init.lua` to run arbitrary commands after the module has been installed or purged.
+You can define `post_install` and `post_purge` hooks in your module's `dot.lua` to run arbitrary commands after the module has been installed or purged.
 
 ```lua
 return {

--- a/README.md
+++ b/README.md
@@ -204,10 +204,7 @@ Example:
 -- modules/swiftshift/dot.lua
 return {
   defaults = {
-    {
-      plist = "./defaults/SwiftShift.plist",
-      app = "com.pablopunk.Swift-Shift", -- Info on how to get this below
-    }
+    ["com.pablopunk.Swift-Shift"] = "./defaults/SwiftShift.plist", -- Info on how to get app id below
   }
 }
 ```
@@ -222,10 +219,7 @@ return {
 ```lua
 return {
   defaults = {
-    {
-      plist = "./defaults/SwiftShift.xml",
-      app = "com.pablopunk.Swift-Shift",
-    }
+    ["com.pablopunk.Swift-Shift"] = "./defaults/SwiftShift.xml",
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ return {
     brew = "brew install neovim ripgrep",
     apt = "sudo apt install -y neovim ripgrep"
   },
+  check = "nvim --version", -- Check if neovim is already installed
   link = {
     ["./config"] = "~/.config/nvim" -- link the whole directory or just one file, your choice
   }
@@ -93,6 +94,32 @@ return {
 ```
 
 In this example, if `brew` is available, it will use that. If not, it will try `apt`, then `yum`.
+
+#### Smart Installation with `check`
+
+To avoid reinstalling tools that are already installed, add a `check` field:
+
+```lua
+-- neovim/dot.lua
+return {
+  install = {
+    brew = "brew install neovim ripgrep",
+    apt = "sudo apt install -y neovim ripgrep"
+  },
+  check = "nvim --version", -- Check if neovim is already installed
+  link = {
+    ["./config"] = "~/.config/nvim"
+  }
+}
+```
+
+The `check` field specifies a command to verify if the tool is already installed. If the command succeeds, `dot` will skip the installation step.
+
+**Examples:**
+- `check = "nvim --version"` for Neovim
+- `check = "git --version"` for Git
+- `check = "node --version"` for Node.js
+- `check = "which docker"` for Docker
 
 ### Linking Files
 

--- a/dot.lua
+++ b/dot.lua
@@ -465,10 +465,15 @@ local function process_install(config)
 
   -- Check if tool is already installed (if check field is provided)
   if config.check then
-    local exit_code, _ = execute(config.check .. " >/dev/null 2>&1")
-    if exit_code == 0 then
-      print_message("info", "install → already installed")
-      return false
+    local handle = io.popen(config.check .. " >/dev/null 2>&1; echo $?")
+    if handle then
+      local result = handle:read "*a"
+      handle:close()
+      local exit_code = tonumber(result:match "(%d+)")
+      if exit_code == 0 then
+        print_message("info", "install → already installed")
+        return false
+      end
     end
   end
 

--- a/dot.lua
+++ b/dot.lua
@@ -519,15 +519,7 @@ local function process_install(config, purge_mode)
   else
     -- Find the first available command and run it
     for cmd_name, cmd_line in pairs(config.install) do
-      -- For bash, always execute. For package managers, check if they exist
-      local should_execute = false
-      if cmd_name == "bash" then
-        should_execute = true
-      else
-        should_execute = command_exists(cmd_name)
-      end
-      
-      if should_execute then
+      if command_exists(cmd_name) then
         print_message("info", "install → using " .. cmd_name)
         local exit_code, output = execute(cmd_line)
         if exit_code == 0 then

--- a/dot.lua
+++ b/dot.lua
@@ -428,6 +428,15 @@ local function process_install(config)
 
   local install_happened = false
 
+  -- Check if tool is already installed (if check field is provided)
+  if config.check then
+    local exit_code, _ = execute(config.check .. " >/dev/null 2>&1")
+    if exit_code == 0 then
+      print_message("info", "install → already installed")
+      return false
+    end
+  end
+
   -- Find the first available command and run it
   for cmd_name, cmd_line in pairs(config.install) do
     if command_exists(cmd_name) then

--- a/dot.lua
+++ b/dot.lua
@@ -492,8 +492,8 @@ local function process_install(config)
         if trimmed_line ~= "" then
           -- For install commands, use os.execute to handle interactive prompts properly
           print_message("info", "install → running: " .. trimmed_line)
-          local exit_code = os.execute(trimmed_line)
-          if exit_code ~= 0 then
+          local result = os.execute(trimmed_line)
+          if result ~= true then
             print_message("error", "install → failed")
             all_succeeded = false
             break

--- a/dot.lua
+++ b/dot.lua
@@ -139,6 +139,7 @@ local function execute(cmd)
     and not cmd:match "installer:"
     and not cmd:match "sudo:"
     and not cmd:match "Please enter"
+    and not cmd:match "^find "
   then
     print(output)
   end

--- a/dot.lua
+++ b/dot.lua
@@ -490,9 +490,11 @@ local function process_install(config)
       for _, line in ipairs(cmd_lines) do
         local trimmed_line = str_trim(line)
         if trimmed_line ~= "" then
-          local exit_code, output = execute(trimmed_line)
+          -- For install commands, use os.execute to handle interactive prompts properly
+          print_message("info", "install → running: " .. trimmed_line)
+          local exit_code = os.execute(trimmed_line)
           if exit_code ~= 0 then
-            print_message("error", "install → failed: " .. (output or "unknown error"))
+            print_message("error", "install → failed")
             all_succeeded = false
             break
           end

--- a/dot.lua
+++ b/dot.lua
@@ -114,12 +114,14 @@ end
 local function execute(cmd)
   -- For ln commands, don't capture output at all
   if cmd:match "^ln " then
-    print("DEBUG: Found ln command: " .. cmd)
     local exit_code = os.execute(cmd .. " > /dev/null 2>&1")
     return exit_code, ""
   end
 
   local handle = io.popen(cmd .. " 2>&1; echo $?")
+  if not handle then
+    return 1, "Failed to execute command"
+  end
   local result = handle:read "*a"
   handle:close()
   local lines = {}
@@ -678,9 +680,7 @@ local function handle_links(config, module_dir, options)
         end
 
         local cmd = string.format('ln -sf "%s" "%s"', source, output)
-        print("DEBUG: Executing command: " .. cmd)
         local exit_code, error_output = execute(cmd)
-        print("DEBUG: Command output: " .. (error_output or "nil"))
         if exit_code ~= 0 then
           print_message("error", "link → failed to create symlink: " .. error_output)
         else

--- a/dot.lua
+++ b/dot.lua
@@ -367,17 +367,17 @@ end
 local function get_all_modules()
   local modules = {}
   local modules_dir = "modules"
-  -- Find all init.lua files within modules directory
-  local cmd = string.format('find "%s" -type f -name "init.lua"', modules_dir)
+  -- Find all dot.lua files within modules directory
+  local cmd = string.format('find "%s" -type f -name "dot.lua"', modules_dir)
   local exit_code, output = execute(cmd)
   if exit_code == 0 then
-    -- First pass: collect all init.lua files
+    -- First pass: collect all dot.lua files
     local all_init_files = {}
     for file in output:gmatch "[^\n]+" do
       table.insert(all_init_files, file)
     end
 
-    -- Sort init.lua files by path length (shortest first) to ensure parent modules are processed first
+    -- Sort dot.lua files by path length (shortest first) to ensure parent modules are processed first
     table.sort(all_init_files, function(a, b)
       return #a < #b
     end)
@@ -387,11 +387,11 @@ local function get_all_modules()
 
     for _, file in ipairs(all_init_files) do
       -- Extract the module path relative to modules_dir
-      local module_path = file:match("^" .. modules_dir .. "/(.+)/init.lua$")
+      local module_path = file:match("^" .. modules_dir .. "/(.+)/dot.lua$")
       if module_path then
         local is_nested = false
 
-        -- Check if any parent directory already has init.lua
+        -- Check if any parent directory already has dot.lua
         local path_parts = {}
         for part in module_path:gmatch "[^/]+" do
           table.insert(path_parts, part)
@@ -413,7 +413,7 @@ local function get_all_modules()
 
         if not is_nested then
           -- This is a top-level module or one without parent modules
-          local module_name = module_path:gsub("/init.lua$", "")
+          local module_name = module_path
           table.insert(modules, module_name)
 
           -- Mark this path as having a module
@@ -678,10 +678,10 @@ local function process_module(module_name, options)
   print_section(module_name)
 
   local module_dir = "modules/" .. module_name
-  local init_file = module_dir .. "/init.lua"
+  local dot_file = module_dir .. "/dot.lua"
 
-  -- Load the init.lua file
-  local config_func, load_err = loadfile(init_file)
+  -- Load the dot.lua file
+  local config_func, load_err = loadfile(dot_file)
   if not config_func then
     print_message("error", "Error loading configuration: " .. load_err)
     return
@@ -817,7 +817,7 @@ local function process_tool(tool_name, options)
       return false
     else
       -- Check for exact module path
-      local module_path = "modules/" .. tool_name .. "/init.lua"
+      local module_path = "modules/" .. tool_name .. "/dot.lua"
       if is_file(module_path) then
         process_module(tool_name, options)
         return true

--- a/dot.lua
+++ b/dot.lua
@@ -490,7 +490,7 @@ local function process_install(config)
 end
 
 -- Process macOS defaults
-local function process_defaults(config, options)
+local function process_defaults(config, options, module_dir)
   if not config.defaults then
     return false
   end
@@ -504,10 +504,10 @@ local function process_defaults(config, options)
   local defaults_processed = false
 
   for app_id, plist_path in pairs(config.defaults) do
-    -- Make relative paths relative to current working directory
+    -- Make relative paths relative to module directory
     local full_plist_path = plist_path or ""
     if plist_path and full_plist_path ~= "" and not full_plist_path:match "^/" then
-      full_plist_path = os.getenv "PWD" .. "/" .. full_plist_path:gsub("^./", "")
+      full_plist_path = os.getenv "PWD" .. "/" .. module_dir:gsub("^./", "") .. "/" .. full_plist_path:gsub("^./", "")
     end
 
     if not full_plist_path or full_plist_path == "" then
@@ -750,7 +750,7 @@ local function process_module(module_name, options)
   end
 
   -- Process defaults
-  if process_defaults(config, options) then
+  if process_defaults(config, options, module_dir) then
     defaults_happened = true
   end
 

--- a/dot.lua
+++ b/dot.lua
@@ -838,11 +838,18 @@ local function process_tool(tool_name, options)
         process_module(matches[1], options)
         return true
       elseif #matches > 1 then
-        print_message("error", "Multiple modules match '" .. tool_name .. "':")
+        -- Multiple matches found - install all of them
+        print_message("info", "Multiple modules match '" .. tool_name .. "':")
         for _, match in ipairs(matches) do
           print_message("info", "  " .. match)
         end
-        return false
+        print_message("info", "Installing all matching modules...")
+
+        local all_success = true
+        for _, match in ipairs(matches) do
+          process_module(match, options)
+        end
+        return all_success
       else
         -- Check for exact module path
         local module_path = tool_name .. "/dot.lua"
@@ -868,11 +875,18 @@ local function process_tool(tool_name, options)
       process_module(matches[1], options)
       return true
     elseif #matches > 1 then
-      print_message("error", "Multiple modules match '" .. tool_name .. "':")
+      -- Multiple matches found - install all of them
+      print_message("info", "Multiple modules match '" .. tool_name .. "':")
       for _, match in ipairs(matches) do
         print_message("info", "  " .. match)
       end
-      return false
+      print_message("info", "Installing all matching modules...")
+
+      local all_success = true
+      for _, match in ipairs(matches) do
+        process_module(match, options)
+      end
+      return all_success
     else
       -- Check for exact module path
       local module_path = tool_name .. "/dot.lua"

--- a/dot.lua
+++ b/dot.lua
@@ -771,15 +771,15 @@ local function process_tool(tool_name, options)
     end
 
     local profile = profiles[tool_name]
-    if not profile.modules then
-      print_message("error", "Invalid profile structure: missing modules field")
+    if not profile then
+      print_message("error", "Invalid profile structure: profile should be a list of modules")
       return false
     end
 
     local modules_to_process = {}
     local exclusions = {}
 
-    for _, module_name in ipairs(profile.modules) do
+    for _, module_name in ipairs(profile) do
       if module_name:sub(1, 1) == "!" then
         table.insert(exclusions, module_name:sub(2))
       elseif module_name == "*" then

--- a/dot.lua
+++ b/dot.lua
@@ -519,7 +519,15 @@ local function process_install(config, purge_mode)
   else
     -- Find the first available command and run it
     for cmd_name, cmd_line in pairs(config.install) do
-      if cmd_name == "bash" or command_exists(cmd_name) then
+      -- For bash, always execute. For package managers, check if they exist
+      local should_execute = false
+      if cmd_name == "bash" then
+        should_execute = true
+      else
+        should_execute = command_exists(cmd_name)
+      end
+      
+      if should_execute then
         print_message("info", "install → using " .. cmd_name)
         local exit_code, output = execute(cmd_line)
         if exit_code == 0 then
@@ -530,7 +538,7 @@ local function process_install(config, purge_mode)
         else
           print_message("error", "install → failed: " .. (output or "unknown error"))
         end
-        break
+        break  -- Only use the first available package manager
       end
     end
     

--- a/dot.lua
+++ b/dot.lua
@@ -6,7 +6,8 @@ local version = "1.0.0"
 local function parse_args()
   local force_mode = false
   local unlink_mode = false
-  local hooks_mode = false
+  local postinstall_mode = false
+  local postlink_mode = false
   local defaults_export = false
   local defaults_import = false
   local remove_profile = false
@@ -29,8 +30,10 @@ local function parse_args()
       defaults_import = true
     elseif arg[i] == "-i" then
       defaults_import = true
-    elseif arg[i] == "--hooks" then
-      hooks_mode = true
+    elseif arg[i] == "--postinstall" then
+      postinstall_mode = true
+    elseif arg[i] == "--postlink" then
+      postlink_mode = true
     elseif arg[i] == "--remove-profile" then
       remove_profile = true
     elseif arg[i] == "-h" then
@@ -46,7 +49,8 @@ Options:
   --defaults-export Save app preferences to a plist file
   -i                ↙ Short for --defaults-import
   --defaults-import Import app preferences from a plist file
-  --hooks           Run hooks even if dependencies haven't changed
+  --postinstall     Run postinstall hooks even if dependencies haven't changed
+  --postlink        Run postlink hooks even if symlinks haven't changed
   --remove-profile  Remove the last used profile
   -h                Display this help message
 ]]
@@ -63,7 +67,8 @@ Options:
     unlink_mode = unlink_mode,
     defaults_export = defaults_export,
     defaults_import = defaults_import,
-    hooks_mode = hooks_mode,
+    postinstall_mode = postinstall_mode,
+    postlink_mode = postlink_mode,
     remove_profile = remove_profile,
     args = args,
   }
@@ -712,13 +717,13 @@ local function process_module(module_name, options)
   end
 
   -- Run new hook system
-  if install_happened or options.hooks_mode then
+  if install_happened or options.postinstall_mode then
     if config.postinstall then
       run_hook(config.postinstall, "postinstall")
     end
   end
 
-  if link_happened or options.hooks_mode then
+  if link_happened or options.postlink_mode then
     if not options.unlink_mode and config.postlink then
       run_hook(config.postlink, "postlink")
     end

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Detect OS
+detect_os() {
+    case "$(uname -s)" in
+        Darwin*)    echo "macos";;
+        Linux*)     echo "linux";;
+        *)          echo "unknown";;
+    esac
+}
+
+# Check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Install Lua on macOS
+install_lua_macos() {
+    if command_exists brew; then
+        print_status "Installing Lua via Homebrew..."
+        brew install lua
+    else
+        print_error "Homebrew not found. Please install Homebrew first:"
+        echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+        exit 1
+    fi
+}
+
+# Install Lua on Linux
+install_lua_linux() {
+    if command_exists apt-get; then
+        print_status "Installing Lua via apt..."
+        sudo apt-get update
+        sudo apt-get install -y lua5.4
+    elif command_exists yum; then
+        print_status "Installing Lua via yum..."
+        sudo yum install -y lua
+    elif command_exists dnf; then
+        print_status "Installing Lua via dnf..."
+        sudo dnf install -y lua
+    elif command_exists pacman; then
+        print_status "Installing Lua via pacman..."
+        sudo pacman -S --noconfirm lua
+    elif command_exists zypper; then
+        print_status "Installing Lua via zypper..."
+        sudo zypper install -y lua
+    else
+        print_error "No supported package manager found. Please install Lua manually."
+        exit 1
+    fi
+}
+
+
+
+# Install dot tool
+install_dot() {
+    local os=$(detect_os)
+    local install_dir="$HOME/.local/bin"
+    local dot_path="$install_dir/dot"
+    
+    # Create install directory
+    mkdir -p "$install_dir"
+    
+    # Download the dot.lua file
+    print_status "Downloading dot tool..."
+    if command_exists curl; then
+        curl -fsSL "https://raw.githubusercontent.com/pablopunk/dot/main/dot.lua" -o "$dot_path"
+    elif command_exists wget; then
+        wget -qO "$dot_path" "https://raw.githubusercontent.com/pablopunk/dot/main/dot.lua"
+    else
+        print_error "Neither curl nor wget found. Please install one of them."
+        exit 1
+    fi
+    
+    # Make it executable
+    chmod +x "$dot_path"
+    
+    # Check if directory is already in PATH
+    if [[ ":$PATH:" == *":$install_dir:"* ]]; then
+        print_success "PATH already includes $install_dir"
+    else
+        print_warning "The dot tool is installed to $install_dir"
+        print_warning "To use it, either:"
+        echo "  1. Add $install_dir to your PATH manually"
+        echo "  2. Run the tool directly: $install_dir/dot"
+        echo "  3. Create a symlink: ln -s $install_dir/dot /usr/local/bin/dot"
+    fi
+    
+    print_success "dot tool installed to $dot_path"
+}
+
+# Main installation process
+main() {
+    print_status "Starting dot tool installation..."
+    
+    local os=$(detect_os)
+    print_status "Detected OS: $os"
+    
+    # Check if Lua is installed
+    if ! command_exists lua; then
+        print_status "Lua not found. Installing Lua..."
+        case "$os" in
+            macos) install_lua_macos;;
+            linux) install_lua_linux;;
+            *) print_error "Unsupported OS: $os"; exit 1;;
+        esac
+    else
+        print_success "Lua already installed"
+    fi
+    
+    # Install dot tool
+    install_dot
+    
+    print_success "Installation complete!"
+    echo
+    print_status "Installation details:"
+    echo "  Location: $HOME/.local/bin/dot"
+    echo
+    print_status "Usage:"
+    echo "  $HOME/.local/bin/dot            # Install all modules"
+    echo "  $HOME/.local/bin/dot neovim     # Install only the 'neovim' module"
+    echo "  $HOME/.local/bin/dot work       # Install only the 'work' profile"
+    echo "  $HOME/.local/bin/dot -h         # Show help"
+    echo
+    print_status "To make 'dot' available as a command, add $HOME/.local/bin to your PATH"
+}
+
+# Run main function
+main "$@" 

--- a/install.sh
+++ b/install.sh
@@ -146,6 +146,7 @@ main() {
     echo "  $HOME/.local/bin/dot            # Install all modules"
     echo "  $HOME/.local/bin/dot neovim     # Install only the 'neovim' module"
     echo "  $HOME/.local/bin/dot work       # Install only the 'work' profile"
+    echo "  $HOME/.local/bin/dot --update   # Update dot tool to latest version"
     echo "  $HOME/.local/bin/dot -h         # Show help"
     echo
     print_status "To make 'dot' available as a command, add $HOME/.local/bin to your PATH"

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -847,49 +847,7 @@ return {
     end
   end)
 
-  it("should handle purge mode", function()
-    -- Create package manager
-    create_command("fake_apt", 0, "Package installed successfully")
 
-    -- Set up module with postpurge hook
-    setup_module(
-      "test_purge",
-      string.format(
-        [[
-return {
-  install = {
-    fake_apt = "fake_apt install -y test-package",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/test",
-  },
-  postpurge = "touch %s/postpurge_executed.marker",
-}
-]],
-        home_dir
-      )
-    )
-
-    -- Create config
-    pl_file.write(pl_path.join(modules_dir, "test_purge", "config"), "test config")
-
-    -- First run to create symlink
-    assert.is_true(run_dot "test_purge")
-
-    -- Verify symlink exists
-    local config_path = pl_path.join(home_dir, ".config", "test")
-    assert.is_true(is_link(config_path), "Symlink should exist after first run")
-
-    -- Run with purge mode and hooks to force postpurge hook execution
-    assert.is_true(run_dot "--purge --hooks test_purge")
-
-    -- Check that symlink was removed
-    assert.is_false(path_exists(config_path), "Symlink should have been removed")
-
-    -- Check that postpurge hook ran (using --hooks to force execution)
-    local postpurge_marker = pl_path.join(home_dir, "postpurge_executed.marker")
-    assert.is_true(path_exists(postpurge_marker), "postpurge hook should have executed")
-  end)
 
   it("should run postlink hooks when linking happens", function()
     -- Set up module with postlink hook

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -189,7 +189,7 @@ if [ -f "%s/$1" ]; then
   echo "%s/$1"
   exit 0
 else
-  exit 1
+  /usr/bin/which "$1" 2>/dev/null || exit 1
 fi
 ]],
       bin_dir,
@@ -244,6 +244,17 @@ echo "COMMAND_EXECUTED: mkdir $@" >> %q
     pl_file.write(pl_path.join(bin_dir, "fake_mkdir"), mkdir_script)
     os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "fake_mkdir")))
 
+    -- Create a real mkdir command that actually works
+    local real_mkdir_script = string.format(
+      [[#!/bin/sh
+echo "COMMAND_EXECUTED: mkdir $@" >> %q
+/bin/mkdir "$@"
+]],
+      command_log_file
+    )
+    pl_file.write(pl_path.join(bin_dir, "mkdir"), real_mkdir_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "mkdir")))
+
     local ln_script = string.format(
       [[#!/bin/sh
 echo "COMMAND_EXECUTED: ln $@" >> %q
@@ -254,6 +265,17 @@ echo "COMMAND_EXECUTED: ln $@" >> %q
     )
     pl_file.write(pl_path.join(bin_dir, "fake_ln"), ln_script)
     os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "fake_ln")))
+
+    -- Create a real ln command that actually works
+    local real_ln_script = string.format(
+      [[#!/bin/sh
+echo "COMMAND_EXECUTED: ln $@" >> %q
+/bin/ln "$@"
+]],
+      command_log_file
+    )
+    pl_file.write(pl_path.join(bin_dir, "ln"), real_ln_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "ln")))
 
     local echo_script = string.format(
       [[#!/bin/sh

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -77,29 +77,35 @@ describe("dot.lua", function()
   end)
 
   it("should install all modules", function()
-    -- Set up 'neovim' module
+    -- Set up 'neovim' module with new structure
     setup_module(
       "neovim",
       [[
 return {
-  brew = { "neovim" },
-  config = {
-    source = "./config",
-    output = "~/.config/nvim",
+  install = {
+    brew = "brew install neovim",
+    apt = "sudo apt install -y neovim",
+    dnf = "sudo dnf install -y neovim",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/nvim",
   }
 }
 ]]
     )
 
-    -- Set up 'zsh' module
+    -- Set up 'zsh' module with new structure
     setup_module(
       "zsh",
       [[
 return {
-  brew = { "zsh" },
-  config = {
-    source = "./zshrc",
-    output = "~/.zshrc",
+  install = {
+    brew = "brew install zsh",
+    apt = "sudo apt install -y zsh",
+    bash = "curl -fsSL https://z.sh | bash -s",
+  },
+  link = {
+    ["./zshrc"] = "$HOME/.zshrc",
   }
 }
 ]]
@@ -121,15 +127,17 @@ return {
   end)
 
   it("should install a specific module", function()
-    -- Set up 'neovim' module
+    -- Set up 'neovim' module with new structure
     setup_module(
       "neovim",
       [[
 return {
-  brew = { "neovim" },
-  config = {
-    source = "./config",
-    output = "~/.config/nvim",
+  install = {
+    brew = "brew install neovim",
+    apt = "sudo apt install -y neovim",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/nvim",
   }
 }
 ]]
@@ -150,29 +158,33 @@ return {
   end)
 
   it("should install a profile", function()
-    -- Set up 'neovim' module
+    -- Set up 'neovim' module with new structure
     setup_module(
       "neovim",
       [[
 return {
-  brew = { "neovim" },
-  config = {
-    source = "./config",
-    output = "~/.config/nvim",
+  install = {
+    brew = "brew install neovim",
+    apt = "sudo apt install -y neovim",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/nvim",
   }
 }
 ]]
     )
 
-    -- Set up 'zsh' module
+    -- Set up 'zsh' module with new structure
     setup_module(
       "zsh",
       [[
 return {
-  brew = { "zsh" },
-  config = {
-    source = "./zshrc",
-    output = "~/.zshrc",
+  install = {
+    brew = "brew install zsh",
+    apt = "sudo apt install -y zsh",
+  },
+  link = {
+    ["./zshrc"] = "$HOME/.zshrc",
   }
 }
 ]]
@@ -206,43 +218,46 @@ return {
   end)
 
   it("should handle exclusions in profiles", function()
-    -- Set up 'neovim' module
+    -- Set up 'neovim' module with new structure
     setup_module(
       "neovim",
       [[
 return {
-  brew = { "neovim" },
-  config = {
-    source = "./config",
-    output = "~/.config/nvim",
+  install = {
+    brew = "brew install neovim",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/nvim",
   }
 }
 ]]
     )
 
-    -- Set up 'zsh' module
+    -- Set up 'zsh' module with new structure
     setup_module(
       "zsh",
       [[
 return {
-  brew = { "zsh" },
-  config = {
-    source = "./zshrc",
-    output = "~/.zshrc",
+  install = {
+    brew = "brew install zsh",
+  },
+  link = {
+    ["./zshrc"] = "$HOME/.zshrc",
   }
 }
 ]]
     )
 
-    -- Set up 'apps/work' module
+    -- Set up 'apps/work' module with new structure
     setup_module(
       "apps/work",
       [[
 return {
-  brew = { "work-app" },
-  config = {
-    source = "./config",
-    output = "~/.config/work-app",
+  install = {
+    brew = "brew install work-app",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/work-app",
   }
 }
 ]]
@@ -281,23 +296,20 @@ return {
   end)
 
   it("should replace existing configs in force mode", function()
-    -- Set up 'neovim' module
+    -- Set up 'neovim' module with new structure
     setup_module(
       "neovim",
-      string.format(
-        [[
+      [[
 return {
-  brew = { "neovim" },
-  config = {
-    source = "./config",
-    output = "~/.config/nvim",
+  install = {
+    brew = "brew install neovim",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/nvim",
   }
 }
-]],
-        home_dir,
-        home_dir
-      )
-    ) -- Ensure absolute paths if needed
+]]
+    )
 
     -- Create existing config
     local nvim_config = pl_path.join(home_dir, ".config", "nvim")
@@ -327,15 +339,16 @@ return {
   end)
 
   it("should unlink configs with --unlink", function()
-    -- Set up 'neovim' module
+    -- Set up 'neovim' module with new structure
     setup_module(
       "neovim",
       [[
 return {
-  brew = { "neovim" },
-  config = {
-    source = "./config",
-    output = "~/.config/nvim",
+  install = {
+    brew = "brew install neovim",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/nvim",
   }
 }
 ]]
@@ -366,15 +379,16 @@ return {
   end)
 
   it("should purge modules with --purge", function()
-    -- Set up 'neovim' module
+    -- Set up 'neovim' module with new structure
     setup_module(
       "neovim",
       [[
 return {
-  brew = { "neovim" },
-  config = {
-    source = "./config",
-    output = "~/.config/nvim",
+  install = {
+    brew = "brew install neovim",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/nvim",
   }
 }
 ]]
@@ -397,22 +411,24 @@ return {
     assert.is_false(path_exists(nvim_config), "Expected nvim_config to be removed after purge")
   end)
 
-  it("should run hooks", function()
-    -- Set up 'dummy_app' module with hooks using absolute paths
+  it("should run new hook system", function()
+    -- Set up 'dummy_app' module with new hooks using absolute paths
     setup_module(
       "dummy_app",
       string.format(
         [[
 return {
-  brew = { },
-  config = {
-    source = "./config",
-    output = "~/.config/dummy_app",
+  install = {
+    bash = "touch %s/.install_ran",
   },
-  post_install = "touch %s/.hooks_post_install_ran",
-  post_purge = "touch %s/.hooks_post_purge_ran",
+  link = {
+    ["./config"] = "$HOME/.config/dummy_app",
+  },
+  postinstall = "touch %s/.hooks_postinstall_ran",
+  postlink = "touch %s/.hooks_postlink_ran",
 }
 ]],
+        home_dir,
         home_dir,
         home_dir
       )
@@ -425,54 +441,78 @@ return {
     -- Run dot.lua to install 'dummy_app'
     assert.is_true(run_dot "dummy_app")
 
-    -- Check if post_install hook ran
-    local hook_install = pl_path.join(home_dir, ".hooks_post_install_ran")
-    print("Checking for hook_install at:", hook_install)
-    assert.is_true(path_exists(hook_install), "Post-install hook did not run")
+    -- Check if postinstall hook ran (should run because install happened)
+    local hook_postinstall = pl_path.join(home_dir, ".hooks_postinstall_ran")
+    assert.is_true(path_exists(hook_postinstall), "Post-install hook did not run")
 
-    -- Run dot.lua with --purge option for 'dummy_app'
-    assert.is_true(run_dot "--purge dummy_app")
+    -- Check if postlink hook ran (should run because link happened)
+    local hook_postlink = pl_path.join(home_dir, ".hooks_postlink_ran")
+    assert.is_true(path_exists(hook_postlink), "Post-link hook did not run")
 
-    -- Check if post_purge hook ran
-    local hook_purge = pl_path.join(home_dir, ".hooks_post_purge_ran")
-    print("Checking for hook_purge at:", hook_purge)
-    assert.is_true(path_exists(hook_purge), "Post-purge hook did not run")
+    -- Check if install command ran
+    local install_ran = pl_path.join(home_dir, ".install_ran")
+    assert.is_true(path_exists(install_ran), "Install command did not run")
   end)
 
-  it("should handle multiple configs in a module", function()
-    -- Set up 'multi_config' module with multiple configs
+  it("should handle multiple links in a module", function()
+    -- Set up 'multi_link' module with multiple links
     setup_module(
-      "multi_config",
+      "multi_link",
       [[
 return {
-  brew = { },
-  config = {
-    {
-      source = "./config/settings.json",
-      output = "~/settings.json",
-    },
-    {
-      source = "./config/keybindings.json",
-      output = "~/keybindings.json",
-    }
+  link = {
+    ["./config/settings.json"] = "$HOME/settings.json",
+    ["./config/keybindings.json"] = "$HOME/keybindings.json",
   }
 }
 ]]
     )
 
     -- Create config files
-    pl_dir.makepath(pl_path.join(modules_dir, "multi_config", "config"))
-    pl_file.write(pl_path.join(modules_dir, "multi_config", "config", "settings.json"), [[{ "setting": "value" }]])
-    pl_file.write(pl_path.join(modules_dir, "multi_config", "config", "keybindings.json"), [[{ "key": "binding" }]])
+    pl_dir.makepath(pl_path.join(modules_dir, "multi_link", "config"))
+    pl_file.write(pl_path.join(modules_dir, "multi_link", "config", "settings.json"), [[{ "setting": "value" }]])
+    pl_file.write(pl_path.join(modules_dir, "multi_link", "config", "keybindings.json"), [[{ "key": "binding" }]])
 
-    -- Run dot.lua to install 'multi_config'
-    assert.is_true(run_dot "multi_config")
+    -- Run dot.lua to install 'multi_link'
+    assert.is_true(run_dot "multi_link")
 
     -- Check if symlinks are created
     local settings = pl_path.join(home_dir, "settings.json")
     local keybindings = pl_path.join(home_dir, "keybindings.json")
     assert.is_true(is_link(settings), "Expected symlink for settings.json")
     assert.is_true(is_link(keybindings), "Expected symlink for keybindings.json")
+  end)
+
+  it("should support directory linking", function()
+    -- Set up module that links entire directories
+    setup_module(
+      "dir_link",
+      [[
+return {
+  link = {
+    ["./zshrc.d"] = "$HOME/.zshrc.d",
+    ["./config"] = "$HOME/.config/myapp",
+  }
+}
+]]
+    )
+
+    -- Create directory structures
+    pl_dir.makepath(pl_path.join(modules_dir, "dir_link", "zshrc.d"))
+    pl_file.write(pl_path.join(modules_dir, "dir_link", "zshrc.d", "aliases.zsh"), "alias ll='ls -la'")
+    pl_file.write(pl_path.join(modules_dir, "dir_link", "zshrc.d", "exports.zsh"), "export EDITOR=nvim")
+    
+    pl_dir.makepath(pl_path.join(modules_dir, "dir_link", "config"))
+    pl_file.write(pl_path.join(modules_dir, "dir_link", "config", "config.json"), '{"theme": "dark"}')
+
+    -- Run dot.lua to install 'dir_link'
+    assert.is_true(run_dot "dir_link")
+
+    -- Check if directory symlinks are created
+    local zshrc_d = pl_path.join(home_dir, ".zshrc.d")
+    local config_dir = pl_path.join(home_dir, ".config", "myapp")
+    assert.is_true(is_link(zshrc_d), "Expected symlink for .zshrc.d directory")
+    assert.is_true(is_link(config_dir), "Expected symlink for config directory")
   end)
 
   it("should display help message with -h option", function()
@@ -487,112 +527,165 @@ return {
     assert.is_true(output:find(expected_start, 1, true) ~= nil, "Help message not displayed correctly")
   end)
 
-  it("should handle wget configuration", function()
-    -- Set up 'wget_test' module with wget configuration
+  it("should handle OS-specific modules", function()
+    -- Set up a module that only works on the current OS
+    local current_os = io.popen("uname"):read("*l") -- Get the current OS
+    local is_macos = current_os == "Darwin"
+    local is_linux = current_os == "Linux"
+    
+    -- Set up 'os_specific' module for the current OS
     setup_module(
-      "wget_test",
+      "os_specific_current",
       [[
 return {
-  wget = {
-    url = "https://example.com/test.bin",
-    output = "]] .. pl_path.join(home_dir, "test_output") .. [[",
+  os = { "]] .. (is_macos and "darwin" or "linux") .. [[" },
+  link = {
+    ["./config"] = "$HOME/.config/os_specific_current",
   }
 }
 ]]
     )
-
-    -- Run dot.lua for 'wget_test' module with mock-wget
-    assert.is_true(run_dot "wget_test --mock-wget")
-
-    -- Check if the mock download and unzip operations were performed
-    local test_output = pl_path.join(home_dir, "test_output")
-    assert.is_true(path_exists(test_output), "Expected test_output to exist after mock wget operation")
+    
+    -- Set up a module for the other OS
+    setup_module(
+      "os_specific_other",
+      [[
+return {
+  os = { "]] .. (is_macos and "linux" or "darwin") .. [[" },
+  link = {
+    ["./config"] = "$HOME/.config/os_specific_other",
+  }
+}
+]]
+    )
+    
+    -- Create config directories and files
+    pl_dir.makepath(pl_path.join(modules_dir, "os_specific_current", "config"))
+    pl_file.write(pl_path.join(modules_dir, "os_specific_current", "config", "config.txt"), "current os config")
+    
+    pl_dir.makepath(pl_path.join(modules_dir, "os_specific_other", "config"))
+    pl_file.write(pl_path.join(modules_dir, "os_specific_other", "config", "config.txt"), "other os config")
+    
+    -- Run dot.lua without arguments to install all modules
+    assert.is_true(run_dot())
+    
+    -- Check if the current OS module is installed and the other OS module is skipped
+    local current_config = pl_path.join(home_dir, ".config", "os_specific_current")
+    local other_config = pl_path.join(home_dir, ".config", "os_specific_other")
+    
+    assert.is_true(is_link(current_config), "Expected symlink for current OS module")
+    assert.is_false(path_exists(other_config), "Did not expect symlink for other OS module")
   end)
 
-  it("should handle defaults export and import", function()
-    -- Set up 'defaults_test' module with defaults configuration
+  it("should support fuzzy module matching", function()
+    -- Set up nested module structure
     setup_module(
-      "defaults_test",
+      "ricing/hyprland",
       [[
 return {
-  defaults = {
-    {
-      plist = "./defaults/SwiftShift.plist",
-      app = "com.pablopunk.SwiftShift",
-    }
+  install = {
+    apt = "sudo apt install -y hyprland",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/hypr",
   }
 }
 ]]
     )
 
-    -- Create module directory
-    pl_dir.makepath(pl_path.join(modules_dir, "defaults_test", "defaults"))
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "ricing", "hyprland", "config"))
+    pl_file.write(pl_path.join(modules_dir, "ricing", "hyprland", "config", "hyprland.conf"), "# Hyprland config")
 
-    -- Run dot.lua with --defaults-export and --mock-defaults options
-    assert.is_true(run_dot "defaults_test --defaults-export --mock-defaults")
+    -- Test fuzzy matching: 'hypr' should match 'ricing/hyprland'
+    assert.is_true(run_dot "hypr")
 
-    -- Check if the plist file was created
-    local plist_path = pl_path.join(modules_dir, "defaults_test", "defaults", "SwiftShift.plist")
-    assert.is_true(pl_path.isfile(plist_path), "Expected plist file to be created")
-
-    -- Verify the content of the plist file
-    local content = pl_file.read(plist_path)
-    assert.are.equal("mocked preferences", content)
-
-    -- Run dot.lua with --defaults-import and --mock-defaults options
-    assert.is_true(run_dot "defaults_test --defaults-import --mock-defaults")
-    -- Check if the import was successful (mocked, so no actual change)
-    -- This is mainly to ensure no errors occur during the import process
+    -- Check if symlink is created
+    local hypr_config = pl_path.join(home_dir, ".config", "hypr")
+    assert.is_true(is_link(hypr_config), "Expected symlink for hypr config via fuzzy match")
   end)
 
-  it("should handle XML format for defaults export and import", function()
-    -- Set up a module with XML format for defaults
+  it("should handle command detection for install", function()
+    -- Set up module with multiple install options
     setup_module(
-      "defaults_xml_test",
+      "test_detection",
       [[
 return {
-  defaults = {
-    {
-      plist = "./defaults/SwiftShift.xml",
-      app = "com.pablopunk.SwiftShift",
-    }
+  install = {
+    nonexistent_cmd = "nonexistent_cmd install test",
+    bash = "echo 'bash install worked' > ]] .. home_dir .. [[/install_result.txt",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/test_detection",
   }
 }
 ]]
     )
 
-    -- Create module directory
-    pl_dir.makepath(pl_path.join(modules_dir, "defaults_xml_test", "defaults"))
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_detection", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_detection", "config", "test.conf"), "test config")
 
-    -- Run dot.lua with --defaults-export and --mock-defaults options
-    assert.is_true(run_dot "defaults_xml_test --defaults-export --mock-defaults")
+    -- Run dot.lua - should use bash since nonexistent_cmd doesn't exist
+    assert.is_true(run_dot "test_detection")
 
-    -- Check if the XML file was created
-    local xml_path = pl_path.join(modules_dir, "defaults_xml_test", "defaults", "SwiftShift.xml")
-    assert.is_true(pl_path.isfile(xml_path), "Expected XML file to be created")
+    -- Check if bash command was executed
+    local install_result = pl_path.join(home_dir, "install_result.txt")
+    assert.is_true(path_exists(install_result), "Expected bash install command to run")
+    
+    local content = pl_file.read(install_result)
+    assert.are.equal("bash install worked", content:match("^%s*(.-)%s*$"))
+  end)
 
-    -- Verify the content of the XML file
-    local content = pl_file.read(xml_path)
-    assert.is_true(content:match "<plist" ~= nil, "Expected XML content in the file")
-    assert.is_true(content:match "<!DOCTYPE plist" ~= nil, "Expected DOCTYPE in XML content")
-    assert.is_true(content:match "<dict" ~= nil, "Expected dict element in XML content")
+  it("should run postinstall only when install happens", function()
+    -- Set up module with install that does nothing the second time
+    setup_module(
+      "install_once",
+      string.format(
+        [[
+return {
+  install = {
+    bash = "test ! -f %s/.already_installed && touch %s/.already_installed || exit 0",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/install_once",
+  },
+  postinstall = "touch %s/.postinstall_ran",
+}
+]],
+        home_dir, home_dir, home_dir
+      )
+    )
 
-    -- Run dot.lua with --defaults-import and --mock-defaults options
-    assert.is_true(run_dot "defaults_xml_test --defaults-import --mock-defaults")
-    -- Check if the import was successful (mocked, so no actual change)
-    -- This is mainly to ensure no errors occur during the import process
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "install_once", "config"))
+    pl_file.write(pl_path.join(modules_dir, "install_once", "config", "test.conf"), "test config")
+
+    -- First run - should run postinstall
+    assert.is_true(run_dot "install_once")
+    
+    local postinstall_marker = pl_path.join(home_dir, ".postinstall_ran")
+    assert.is_true(path_exists(postinstall_marker), "Expected postinstall to run on first install")
+
+    -- Remove postinstall marker
+    os.remove(postinstall_marker)
+
+    -- Second run - should NOT run postinstall since install already happened
+    assert.is_true(run_dot "install_once")
+    assert.is_false(path_exists(postinstall_marker), "Did not expect postinstall to run on second install")
   end)
 
   it("should save the last used profile", function()
-    -- Set up 'neovim' module
+    -- Set up 'neovim' module with new structure
     setup_module(
       "neovim",
       [[
 return {
-  brew = { "neovim" },
-  config = {
-    source = "./config",
-    output = "~/.config/nvim",
+  install = {
+    brew = "brew install neovim",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/nvim",
   }
 }
 ]]
@@ -623,287 +716,5 @@ return {
 
     local content = pl_file.read(dot_file_path)
     assert.are.equal("test_profile", content:match("^%s*(.-)%s*$"), "Profile name in .dot file is incorrect")
-  end)
-
-  it("should respect OS-specific modules", function()
-    -- Set up a module that only works on the current OS
-    local current_os = io.popen("uname"):read("*l") -- Get the current OS
-    local is_macos = current_os == "Darwin"
-    local is_linux = current_os == "Linux"
-    
-    -- Set up 'os_specific' module for the current OS
-    setup_module(
-      "os_specific_current",
-      [[
-return {
-  os = { "]] .. (is_macos and "mac" or "linux") .. [[" },
-  config = {
-    source = "./config",
-    output = "~/.config/os_specific_current",
-  }
-}
-]]
-    )
-    
-    -- Set up a module for the other OS
-    setup_module(
-      "os_specific_other",
-      [[
-return {
-  os = { "]] .. (is_macos and "linux" or "mac") .. [[" },
-  config = {
-    source = "./config",
-    output = "~/.config/os_specific_other",
-  }
-}
-]]
-    )
-    
-    -- Set up a module that works on multiple OSes
-    setup_module(
-      "os_specific_multi",
-      [[
-return {
-  os = { "mac", "linux" },
-  config = {
-    source = "./config",
-    output = "~/.config/os_specific_multi",
-  }
-}
-]]
-    )
-    
-    -- Create config directories and files
-    pl_dir.makepath(pl_path.join(modules_dir, "os_specific_current", "config"))
-    pl_file.write(pl_path.join(modules_dir, "os_specific_current", "config", "config.txt"), "current os config")
-    
-    pl_dir.makepath(pl_path.join(modules_dir, "os_specific_other", "config"))
-    pl_file.write(pl_path.join(modules_dir, "os_specific_other", "config", "config.txt"), "other os config")
-    
-    pl_dir.makepath(pl_path.join(modules_dir, "os_specific_multi", "config"))
-    pl_file.write(pl_path.join(modules_dir, "os_specific_multi", "config", "config.txt"), "multi os config")
-    
-    -- Run dot.lua without arguments to install all modules
-    assert.is_true(run_dot())
-    
-    -- Check if the current OS module is installed and the other OS module is skipped
-    local current_config = pl_path.join(home_dir, ".config", "os_specific_current")
-    local other_config = pl_path.join(home_dir, ".config", "os_specific_other")
-    local multi_config = pl_path.join(home_dir, ".config", "os_specific_multi")
-    
-    assert.is_true(is_link(current_config), "Expected symlink for current OS module")
-    assert.is_false(path_exists(other_config), "Did not expect symlink for other OS module")
-    assert.is_true(is_link(multi_config), "Expected symlink for multi-OS module")
-  end)
-
-  it("should respect init.lua file hierarchy in modules", function()
-    -- Set up module with both top-level init.lua and subfolder with init.lua
-    local module_dir = pl_path.join(modules_dir, "nested_module")
-    pl_dir.makepath(module_dir)
-
-    -- Create top-level init.lua
-    local top_init_lua = pl_path.join(module_dir, "init.lua")
-    pl_file.write(
-      top_init_lua,
-      [[
-return {
-  brew = { "top-level-package" },
-  config = {
-    source = "./config",
-    output = "~/.config/top-level",
-  }
-}
-]]
-    )
-
-    -- Create config directory and file for the top-level module
-    pl_dir.makepath(pl_path.join(module_dir, "config"))
-    pl_file.write(pl_path.join(module_dir, "config", "top-config.txt"), "top level config")
-
-    -- Create a config subdirectory with its own init.lua
-    local sub_module_dir = pl_path.join(module_dir, "config", "submodule")
-    pl_dir.makepath(sub_module_dir)
-    local sub_init_lua = pl_path.join(sub_module_dir, "init.lua")
-    pl_file.write(
-      sub_init_lua,
-      [[
-return {
-  brew = { "sub-level-package" },
-  config = {
-    source = "./files",
-    output = "~/.config/sub-level",
-  }
-}
-]]
-    )
-
-    -- Create files directory for the submodule
-    pl_dir.makepath(pl_path.join(sub_module_dir, "files"))
-    pl_file.write(pl_path.join(sub_module_dir, "files", "sub-config.txt"), "sub level config")
-
-    -- Run dot.lua for this module
-    assert.is_true(run_dot "nested_module")
-
-    -- Only the top-level module should be installed
-    local top_level_config = pl_path.join(home_dir, ".config", "top-level")
-    local sub_level_config = pl_path.join(home_dir, ".config", "sub-level")
-
-    assert.is_true(is_link(top_level_config), "Expected symlink for top-level module")
-    assert.is_false(
-      path_exists(sub_level_config),
-      "Did not expect symlink for submodule when top-level init.lua exists"
-    )
-
-    -- Now, set up a module where only the subfolder has init.lua
-    local second_module_dir = pl_path.join(modules_dir, "subonly_module")
-    pl_dir.makepath(second_module_dir)
-
-    -- Create a subfolder with init.lua but no top-level init.lua
-    local second_sub_dir = pl_path.join(second_module_dir, "config")
-    pl_dir.makepath(second_sub_dir)
-    local second_sub_init_lua = pl_path.join(second_sub_dir, "init.lua")
-    pl_file.write(
-      second_sub_init_lua,
-      [[
-return {
-  brew = { "sub-only-package" },
-  config = {
-    source = "./files",
-    output = "~/.config/sub-only",
-  }
-}
-]]
-    )
-
-    -- Create files directory for the submodule
-    pl_dir.makepath(pl_path.join(second_sub_dir, "files"))
-    pl_file.write(pl_path.join(second_sub_dir, "files", "sub-only-config.txt"), "sub only config")
-
-    -- Run dot.lua for this module
-    assert.is_true(run_dot "subonly_module/config")
-
-    -- In this case, the subdirectory module should be installed
-    local sub_only_config = pl_path.join(home_dir, ".config", "sub-only")
-
-    assert.is_true(
-      is_link(sub_only_config),
-      "Expected symlink for subdirectory module when no top-level init.lua exists"
-    )
-  end)
-
-  it("should handle nested init.lua files in config directories", function()
-    -- Set up a realistic module structure similar to sketchybar example
-    local module_dir = pl_path.join(modules_dir, "realistic_module")
-    pl_dir.makepath(module_dir)
-
-    -- Create top-level init.lua (module definition)
-    local top_init_lua = pl_path.join(module_dir, "init.lua")
-    pl_file.write(
-      top_init_lua,
-      [[
-return {
-  brew = { "realistic-package" },
-  config = {
-    source = "./config",
-    output = "~/.config/realistic-module",
-  }
-}
-]]
-    )
-
-    -- Create config directory
-    local config_dir = pl_path.join(module_dir, "config")
-    pl_dir.makepath(config_dir)
-
-    -- Create config/init.lua (NOT a module, just a Lua file for the app config)
-    pl_file.write(
-      pl_path.join(config_dir, "init.lua"),
-      [[
--- This is just a config file, not a module definition
-local config = {}
-config.items = require("items")
-return config
-]]
-    )
-
-    -- Create config/items directory with its own init.lua
-    local items_dir = pl_path.join(config_dir, "items")
-    pl_dir.makepath(items_dir)
-    pl_file.write(
-      pl_path.join(items_dir, "init.lua"),
-      [[
--- This is just a component of the config, not a module
-local items = {}
-items.widgets = require("widgets")
-return items
-]]
-    )
-
-    -- Create config/items/widgets directory with its own init.lua
-    local widgets_dir = pl_path.join(items_dir, "widgets")
-    pl_dir.makepath(widgets_dir)
-    pl_file.write(
-      pl_path.join(widgets_dir, "init.lua"),
-      [[
--- This is the deepest nested init.lua, still just config
-return {
-  clock = function() return os.date() end,
-  battery = function() return "100%" end
-}
-]]
-    )
-
-    -- Run dot.lua for the top-level module
-    assert.is_true(run_dot "realistic_module")
-
-    -- Check that the top-level module is installed
-    local module_config = pl_path.join(home_dir, ".config", "realistic-module")
-    assert.is_true(is_link(module_config), "Expected symlink for realistic-module")
-
-    -- Check that all the nested init.lua files are present in the installed config
-    assert.is_true(pl_path.isfile(pl_path.join(module_config, "init.lua")), "Expected init.lua in the installed config")
-    assert.is_true(
-      pl_path.isfile(pl_path.join(module_config, "items", "init.lua")),
-      "Expected items/init.lua in the installed config"
-    )
-    assert.is_true(
-      pl_path.isfile(pl_path.join(module_config, "items", "widgets", "init.lua")),
-      "Expected items/widgets/init.lua in the installed config"
-    )
-
-    -- Verify we can't try to install the nested components as modules
-    local nested_cmd = string.format(
-      "cd %q && HOME=%q lua %q %s --mock-brew 2>&1",
-      dotfiles_dir,
-      home_dir,
-      dot_executable,
-      "realistic_module/config"
-    )
-    local handle = io.popen(nested_cmd)
-    local output = handle:read "*a"
-    handle:close()
-
-    -- Check that the output indicates the module was not found
-    assert.is_true(
-      output:find("Module not found: realistic_module/config", 1, true) ~= nil,
-      "Should report that nested config directory is not a module"
-    )
-
-    local deeply_nested_cmd = string.format(
-      "cd %q && HOME=%q lua %q %s --mock-brew 2>&1",
-      dotfiles_dir,
-      home_dir,
-      dot_executable,
-      "realistic_module/config/items"
-    )
-    local handle = io.popen(deeply_nested_cmd)
-    local output = handle:read "*a"
-    handle:close()
-
-    -- Check that the output indicates the module was not found
-    assert.is_true(
-      output:find("Module not found: realistic_module/config/items", 1, true) ~= nil,
-      "Should report that deeply nested config directory is not a module"
-    )
   end)
 end)

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -1922,4 +1922,33 @@ return {
     local config_path = pl_path.join(home_dir, ".config", "test")
     assert.is_true(is_link(config_path), "Symlink should have been created")
   end)
+
+  it("should handle relative paths in defaults correctly", function()
+    -- Create a module with relative path in defaults
+    create_command("defaults", 0, "Preferences imported successfully")
+
+    setup_module(
+      "test_relative_defaults",
+      [[
+return {
+  install = {
+    fake_apt = "fake_apt install -y test-package",
+  },
+  defaults = {
+    ["com.test.app"] = "./test.xml",
+  }
+}
+]]
+    )
+
+    -- Create the XML file in the module directory
+    pl_dir.makepath(pl_path.join(dotfiles_dir, "test_relative_defaults"))
+    pl_file.write(pl_path.join(dotfiles_dir, "test_relative_defaults", "test.xml"), "test plist content")
+
+    -- Run dot.lua
+    assert.is_true(run_dot "test_relative_defaults")
+
+    -- Check that defaults import was called (the exact path might vary due to temp directories)
+    assert.is_true(was_command_executed "defaults import")
+  end)
 end)

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -89,7 +89,15 @@ exit 0
       lua_path = "/usr/bin/lua" -- Ubuntu/Debian
     end
     if not pl_path.isfile(lua_path) then
-      lua_path = "lua" -- Fallback to PATH
+      -- Try to find lua in PATH using which
+      local handle = io.popen "which lua 2>/dev/null"
+      local which_output = handle:read "*a"
+      handle:close()
+      if which_output and which_output ~= "" then
+        lua_path = which_output:gsub("%s+$", "") -- Remove trailing whitespace
+      else
+        lua_path = "lua" -- Fallback to PATH
+      end
     end
 
     -- Use system lua directly, but put our bin_dir in PATH for fake commands

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -2006,7 +2006,7 @@ return {
     fake_apt = "fake_apt install -y test-package",
   },
   link = {
-    ["./config"] = "$HOME/.config/test",
+    ["./config"] = "$HOME/.config/test_string",
   }
 }
 ]]
@@ -2022,7 +2022,7 @@ return {
     fake_apt = "fake_apt install -y test-package",
   },
   link = {
-    ["./config"] = "$HOME/.config/test",
+    ["./config"] = "$HOME/.config/test_array",
   }
 }
 ]]
@@ -2043,7 +2043,9 @@ return {
     assert.is_true(was_command_executed "fake_apt", "install command should have been executed for array OS")
 
     -- Check that symlinks were created
-    local config_path1 = pl_path.join(home_dir, ".config", "test")
+    local config_path1 = pl_path.join(home_dir, ".config", "test_string")
+    local config_path2 = pl_path.join(home_dir, ".config", "test_array")
     assert.is_true(is_link(config_path1), "Symlink should have been created for string OS")
+    assert.is_true(is_link(config_path2), "Symlink should have been created for array OS")
   end)
 end)

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -378,13 +378,13 @@ return {
   end)
 
   it("should handle bash commands", function()
-    -- Set up module with bash installation
+    -- Set up module with bash installation that calls touch (which we can track)
     setup_module(
       "test_bash",
       string.format([[
 return {
   install = {
-    bash = "echo 'Custom install script executed' > %s/custom_install.log",
+    bash = "touch %s/bash_install_marker.txt",
   },
   link = {
     ["./config"] = "$HOME/.config/test",
@@ -400,15 +400,12 @@ return {
     -- Run dot.lua
     assert.is_true(run_dot "test_bash")
 
-    -- Check that the custom script created its log file (this proves the bash command worked)
-    local log_file = pl_path.join(home_dir, "custom_install.log")
-    assert.is_true(path_exists(log_file), "Custom install script should have created log file")
+    -- Check that touch was executed (since the bash command actually calls touch)
+    assert.is_true(was_command_executed("touch"), "touch should have been executed as part of the bash command")
     
-    -- Check the content of the log file
-    if path_exists(log_file) then
-      local content = pl_file.read(log_file)
-      assert.are.equal("Custom install script executed", content:match("^%s*(.-)%s*$"), "Log file should contain expected content")
-    end
+    -- Check that the marker file was created (this proves the command worked)
+    local marker_file = pl_path.join(home_dir, "bash_install_marker.txt")
+    assert.is_true(path_exists(marker_file), "Bash command should have created marker file")
   end)
 
   it("should handle command failures gracefully", function()

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -15,6 +15,8 @@ describe("dot.lua", function()
   local modules_dir
   local profiles_dir
   local dot_executable
+  local bin_dir
+  local command_log_file
 
   -- Function to check if a path is a symbolic link
   local function is_link(path)
@@ -22,10 +24,67 @@ describe("dot.lua", function()
     return attr and attr.mode == "link"
   end
 
+  -- Function to create a fake command that logs when it's called
+  local function create_command(name, exit_code, output)
+    exit_code = exit_code or 0
+    output = output or ""
+    
+    local cmd_path = pl_path.join(bin_dir, name)
+    local script_content = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: %s $@" >> %q
+echo %q
+exit %d
+]], name, command_log_file, output, exit_code)
+    
+    pl_file.write(cmd_path, script_content)
+    os.execute(string.format("chmod +x %q", cmd_path))
+    return cmd_path
+  end
+
+  -- Function to create a command that creates a marker file when run
+  local function create_marker_command(name, marker_path)
+    local cmd_path = pl_path.join(bin_dir, name)
+    local script_content = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: %s $@" >> %q
+touch %q
+echo "Package %s installed successfully"
+exit 0
+]], name, command_log_file, marker_path, name)
+    
+    pl_file.write(cmd_path, script_content)
+    os.execute(string.format("chmod +x %q", cmd_path))
+    return cmd_path
+  end
+
+  -- Function to check if a command was executed
+  local function was_command_executed(command_name)
+    if not pl_path.isfile(command_log_file) then
+      return false
+    end
+    local log_content = pl_file.read(command_log_file)
+    return log_content:find("COMMAND_EXECUTED: " .. command_name, 1, true) ~= nil
+  end
+
+  -- Function to get command execution count
+  local function get_command_execution_count(command_name)
+    if not pl_path.isfile(command_log_file) then
+      return 0
+    end
+    local log_content = pl_file.read(command_log_file)
+    local count = 0
+    for line in log_content:gmatch("[^\n]+") do
+      if line:find("COMMAND_EXECUTED: " .. command_name, 1, true) then
+        count = count + 1
+      end
+    end
+    return count
+  end
+
   -- Function to run dot.lua with given arguments
   local function run_dot(args)
     args = args or ""
-    local cmd = string.format("cd %q && HOME=%q lua %q %s --mock-brew", dotfiles_dir, home_dir, dot_executable, args)
+    -- Put our bin_dir first, but keep essential system paths for lua and basic tools
+    local cmd = string.format("cd %q && HOME=%q PATH=%q:/usr/bin:/bin lua %q %s", dotfiles_dir, home_dir, bin_dir, dot_executable, args)
     return os.execute(cmd)
   end
 
@@ -56,17 +115,104 @@ describe("dot.lua", function()
     modules_dir = pl_path.join(dotfiles_dir, "modules")
     profiles_dir = pl_path.join(dotfiles_dir, "profiles")
     dot_executable = pl_path.join(dotfiles_dir, "dot.lua")
+    bin_dir = pl_path.join(tmp_dir, "bin")
+    command_log_file = pl_path.join(tmp_dir, "command_log.txt")
 
     -- Create necessary directories
     pl_dir.makepath(dotfiles_dir)
     pl_dir.makepath(home_dir)
     pl_dir.makepath(modules_dir)
     pl_dir.makepath(profiles_dir)
+    pl_dir.makepath(bin_dir)
 
     -- Copy dot.lua to dotfiles_dir
     os.execute(string.format("cp %q %q", "./dot.lua", dot_executable))
     -- Ensure dot.lua is executable
     os.execute(string.format("chmod +x %q", dot_executable))
+    
+    -- Initialize command log file
+    pl_file.write(command_log_file, "")
+    
+    -- Create a smart which command that checks our bin_dir first
+    local which_script = string.format([[#!/bin/bash
+if [ -f "%s/$1" ]; then
+  echo "%s/$1"
+  exit 0
+else
+  exit 1
+fi
+]], bin_dir, bin_dir)
+    pl_file.write(pl_path.join(bin_dir, "which"), which_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "which")))
+    
+    -- Create essential shell commands that lua might need
+    create_command("uname", 0, "Linux")
+    create_command("mktemp", 0, tmp_dir .. "/tmpfile")
+    create_command("test", 0, "")
+    -- Create a functional bash command that can execute scripts
+    local bash_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: bash $@" >> %q
+/bin/bash "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "bash"), bash_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "bash")))
+    
+    -- Create commands that actually do filesystem operations
+    local mkdir_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: mkdir $@" >> %q
+/bin/mkdir "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "mkdir"), mkdir_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "mkdir")))
+    
+    local ln_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: ln $@" >> %q
+/bin/ln "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "ln"), ln_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "ln")))
+    
+    local echo_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: echo $@" >> %q
+/bin/echo "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "echo"), echo_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "echo")))
+    
+    local touch_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: touch $@" >> %q
+/usr/bin/touch "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "touch"), touch_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "touch")))
+    
+    local cp_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: cp $@" >> %q
+/bin/cp "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "cp"), cp_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "cp")))
+    
+    local rm_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: rm $@" >> %q
+/bin/rm "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "rm"), rm_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "rm")))
+    
+    local mv_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: mv $@" >> %q
+/bin/mv "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "mv"), mv_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "mv")))
+    
+    local find_script = string.format([[#!/bin/bash
+echo "COMMAND_EXECUTED: find $@" >> %q
+/usr/bin/find "$@"
+]], command_log_file)
+    pl_file.write(pl_path.join(bin_dir, "find"), find_script)
+    os.execute(string.format("chmod +x %q", pl_path.join(bin_dir, "find")))
   end)
 
   after_each(function()
@@ -76,16 +222,18 @@ describe("dot.lua", function()
     end
   end)
 
-  it("should install all modules", function()
-    -- Set up 'neovim' module with new structure
+  it("should install all modules using real commands", function()
+    -- Create fake package managers
+    create_command("apt", 0, "Package neovim installed successfully")
+    create_command("brew", 0, "Package zsh installed successfully")
+
+    -- Set up 'neovim' module that only uses apt
     setup_module(
       "neovim",
       [[
 return {
   install = {
-    brew = "brew install neovim",
-    apt = "sudo apt install -y neovim",
-    dnf = "sudo dnf install -y neovim",
+    apt = "apt install -y neovim",
   },
   link = {
     ["./config"] = "$HOME/.config/nvim",
@@ -94,15 +242,13 @@ return {
 ]]
     )
 
-    -- Set up 'zsh' module with new structure
+    -- Set up 'zsh' module that only uses brew
     setup_module(
       "zsh",
       [[
 return {
   install = {
     brew = "brew install zsh",
-    apt = "sudo apt install -y zsh",
-    bash = "curl -fsSL https://z.sh | bash -s",
   },
   link = {
     ["./zshrc"] = "$HOME/.zshrc",
@@ -119,6 +265,10 @@ return {
     -- Run dot.lua without arguments to install all modules
     assert.is_true(run_dot())
 
+    -- Check if commands were actually executed
+    assert.is_true(was_command_executed("apt"), "apt command should have been executed")
+    assert.is_true(was_command_executed("brew"), "brew command should have been executed")
+
     -- Check if symlinks are created
     local nvim_config = pl_path.join(home_dir, ".config", "nvim")
     local zshrc = pl_path.join(home_dir, ".zshrc")
@@ -126,46 +276,281 @@ return {
     assert.is_true(is_link(zshrc), "Expected symlink for zshrc")
   end)
 
-  it("should install a specific module", function()
-    -- Set up 'neovim' module with new structure
+  it("should use the first available package manager", function()
+    -- Create both apt and brew commands
+    create_command("apt", 0, "Package installed via apt")
+    create_command("brew", 0, "Package installed via brew")
+
+    -- Set up module with multiple package managers
     setup_module(
-      "neovim",
+      "test_priority",
       [[
 return {
   install = {
-    brew = "brew install neovim",
-    apt = "sudo apt install -y neovim",
+    nonexistent = "nonexistent install test-package",
+    apt = "apt install -y test-package",
+    brew = "brew install test-package",
   },
   link = {
-    ["./config"] = "$HOME/.config/nvim",
+    ["./config"] = "$HOME/.config/test",
   }
 }
 ]]
     )
 
-    -- Create config directories and files
-    pl_dir.makepath(pl_path.join(modules_dir, "neovim", "config"))
-    pl_file.write(pl_path.join(modules_dir, "neovim", "config", "init.vim"), "set number")
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_priority", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_priority", "config", "test.conf"), "test config")
 
-    -- Run dot.lua for 'neovim' module
-    assert.is_true(run_dot "neovim")
+    -- Run dot.lua
+    assert.is_true(run_dot "test_priority")
 
-    -- Check if symlink is created for nvim and no symlink for zshrc
-    local nvim_config = pl_path.join(home_dir, ".config", "nvim")
-    local zshrc = pl_path.join(home_dir, ".zshrc")
-    assert.is_true(is_link(nvim_config), "Expected symlink for nvim_config")
-    assert.is_false(path_exists(zshrc), "Did not expect symlink for zshrc")
+    -- Check that one of the available commands was executed (since pairs order is not guaranteed)
+    local apt_executed = was_command_executed("apt")
+    local brew_executed = was_command_executed("brew")
+    local nonexistent_executed = was_command_executed("nonexistent")
+    
+    assert.is_false(nonexistent_executed, "nonexistent should NOT have been executed")
+    assert.is_true(apt_executed or brew_executed, "either apt or brew should have been executed")
+    assert.is_false(apt_executed and brew_executed, "only one package manager should be executed")
   end)
 
-  it("should install a profile", function()
-    -- Set up 'neovim' module with new structure
+  it("should use fallback commands when preferred is not available", function()
+    -- Only create brew command (not apt)
+    create_command("brew", 0, "Package installed via brew")
+
+    -- Set up module that prefers apt but falls back to brew
+    setup_module(
+      "test_fallback",
+      [[
+return {
+  install = {
+    apt = "apt install -y test-package",
+    brew = "brew install test-package",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/test",
+  }
+}
+]]
+    )
+
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_fallback", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_fallback", "config", "test.conf"), "test config")
+
+    -- Run dot.lua
+    assert.is_true(run_dot "test_fallback")
+
+    -- Check that brew was used as fallback
+    assert.is_false(was_command_executed("apt"), "apt should NOT have been executed (doesn't exist)")
+    assert.is_true(was_command_executed("brew"), "brew should have been executed as fallback")
+  end)
+
+  it("should handle custom package managers", function()
+    -- Create a custom package manager
+    create_command("pacman", 0, "Package installed via pacman")
+
+    -- Set up module with custom package manager
+    setup_module(
+      "test_custom",
+      [[
+return {
+  install = {
+    pacman = "pacman -S test-package",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/test",
+  }
+}
+]]
+    )
+
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_custom", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_custom", "config", "test.conf"), "test config")
+
+    -- Run dot.lua
+    assert.is_true(run_dot "test_custom")
+
+    -- Check that pacman was executed
+    assert.is_true(was_command_executed("pacman"), "pacman should have been executed")
+  end)
+
+  it("should handle bash commands", function()
+    -- Set up module with bash installation
+    setup_module(
+      "test_bash",
+      string.format([[
+return {
+  install = {
+    bash = "echo 'Custom install script executed' > %s/custom_install.log",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/test",
+  }
+}
+]], home_dir)
+    )
+
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_bash", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_bash", "config", "test.conf"), "test config")
+
+    -- Run dot.lua
+    assert.is_true(run_dot "test_bash")
+
+    -- Check that the custom script created its log file (this proves the bash command worked)
+    local log_file = pl_path.join(home_dir, "custom_install.log")
+    assert.is_true(path_exists(log_file), "Custom install script should have created log file")
+    
+    -- Check the content of the log file
+    if path_exists(log_file) then
+      local content = pl_file.read(log_file)
+      assert.are.equal("Custom install script executed", content:match("^%s*(.-)%s*$"), "Log file should contain expected content")
+    end
+  end)
+
+  it("should handle command failures gracefully", function()
+    -- Create a command that fails
+    create_command("failing_cmd", 1, "Installation failed")
+
+    -- Set up module with failing command
+    setup_module(
+      "test_failure",
+      [[
+return {
+  install = {
+    failing_cmd = "failing_cmd install test-package",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/test",
+  }
+}
+]]
+    )
+
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_failure", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_failure", "config", "test.conf"), "test config")
+
+    -- Run dot.lua (should complete despite install failure)
+    assert.is_true(run_dot "test_failure")
+
+    -- Check that the failing command was attempted
+    assert.is_true(was_command_executed("failing_cmd"), "failing_cmd should have been executed")
+
+    -- Links should still be created despite install failure
+    local test_config = pl_path.join(home_dir, ".config", "test")
+    assert.is_true(is_link(test_config), "Expected symlink despite install failure")
+  end)
+
+  it("should run postinstall hooks when installation happens", function()
+    -- Create package manager
+    local marker_file = pl_path.join(home_dir, "package_installed.marker")
+    create_marker_command("apt", marker_file)
+
+    -- Set up module with postinstall hook
+    setup_module(
+      "test_hooks",
+      string.format([[
+return {
+  install = {
+    apt = "apt install -y test-package",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/test",
+  },
+  postinstall = "touch %s/postinstall_executed.marker",
+}
+]], home_dir)
+    )
+
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_hooks", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_hooks", "config", "test.conf"), "test config")
+
+    -- Run dot.lua
+    assert.is_true(run_dot "test_hooks")
+
+    -- Check that install happened
+    assert.is_true(was_command_executed("apt"), "apt should have been executed")
+    assert.is_true(path_exists(marker_file), "Package should have been installed")
+
+    -- Check that postinstall hook ran
+    local postinstall_marker = pl_path.join(home_dir, "postinstall_executed.marker")
+    assert.is_true(path_exists(postinstall_marker), "postinstall hook should have executed")
+  end)
+
+  it("should not run postinstall when no installation happens", function()
+    -- Set up module without any install commands
+    setup_module(
+      "test_no_install",
+      string.format([[
+return {
+  link = {
+    ["./config"] = "$HOME/.config/test",
+  },
+  postinstall = "touch %s/postinstall_executed.marker",
+}
+]], home_dir)
+    )
+
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_no_install", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_no_install", "config", "test.conf"), "test config")
+
+    -- Run dot.lua
+    assert.is_true(run_dot "test_no_install")
+
+    -- Check that no postinstall hook ran
+    local postinstall_marker = pl_path.join(home_dir, "postinstall_executed.marker")
+    assert.is_false(path_exists(postinstall_marker), "postinstall hook should NOT have executed")
+  end)
+
+  it("should run install commands on every run (realistic behavior)", function()
+    -- Create package manager that succeeds
+    create_command("apt", 0, "Package installed successfully")
+
+    -- Set up module
+    setup_module(
+      "test_repeated",
+      [[
+return {
+  install = {
+    apt = "apt install -y test-package",
+  },
+  link = {
+    ["./config"] = "$HOME/.config/test",
+  }
+}
+]]
+    )
+
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "test_repeated", "config"))
+    pl_file.write(pl_path.join(modules_dir, "test_repeated", "config", "test.conf"), "test config")
+
+    -- Run dot.lua twice
+    assert.is_true(run_dot "test_repeated")
+    assert.is_true(run_dot "test_repeated")
+
+    -- Check that apt was executed both times (realistic behavior - package managers handle idempotency)
+    assert.are.equal(2, get_command_execution_count("apt"), "apt should be executed on every run")
+  end)
+
+  it("should handle profiles correctly", function()
+    -- Create package managers
+    create_command("apt", 0, "Package installed via apt")
+    create_command("brew", 0, "Package installed via brew")
+
+    -- Set up multiple modules
     setup_module(
       "neovim",
       [[
 return {
   install = {
-    brew = "brew install neovim",
-    apt = "sudo apt install -y neovim",
+    apt = "apt install -y neovim",
   },
   link = {
     ["./config"] = "$HOME/.config/nvim",
@@ -174,14 +559,12 @@ return {
 ]]
     )
 
-    -- Set up 'zsh' module with new structure
     setup_module(
       "zsh",
       [[
 return {
   install = {
     brew = "brew install zsh",
-    apt = "sudo apt install -y zsh",
   },
   link = {
     ["./zshrc"] = "$HOME/.zshrc",
@@ -190,41 +573,48 @@ return {
 ]]
     )
 
-    -- Create 'work' profile
+    -- Create work profile that only includes neovim
     setup_profile(
       "work",
       [[
 return {
   modules = {
-    "*"
+    "neovim"
   }
 }
 ]]
     )
 
-    -- Create config directories and files
+    -- Create configs
     pl_dir.makepath(pl_path.join(modules_dir, "neovim", "config"))
     pl_file.write(pl_path.join(modules_dir, "neovim", "config", "init.vim"), "set number")
     pl_file.write(pl_path.join(modules_dir, "zsh", "zshrc"), "export ZSH=~/.oh-my-zsh")
 
-    -- Run dot.lua with 'work' profile
+    -- Run with work profile
     assert.is_true(run_dot "work")
 
-    -- Check if symlinks are created for both modules
+    -- Check that only apt was executed (neovim), not brew (zsh)
+    assert.is_true(was_command_executed("apt"), "apt should have been executed for neovim")
+    assert.is_false(was_command_executed("brew"), "brew should NOT have been executed (zsh not in profile)")
+
+    -- Check that only neovim symlink was created
     local nvim_config = pl_path.join(home_dir, ".config", "nvim")
     local zshrc = pl_path.join(home_dir, ".zshrc")
     assert.is_true(is_link(nvim_config), "Expected symlink for nvim_config")
-    assert.is_true(is_link(zshrc), "Expected symlink for zshrc")
+    assert.is_false(path_exists(zshrc), "zshrc should not exist (not in profile)")
   end)
 
-  it("should handle exclusions in profiles", function()
-    -- Set up 'neovim' module with new structure
+  it("should save and use last profile", function()
+    -- Create package manager
+    create_command("apt", 0, "Package installed via apt")
+
+    -- Set up module
     setup_module(
       "neovim",
       [[
 return {
   install = {
-    brew = "brew install neovim",
+    apt = "apt install -y neovim",
   },
   link = {
     ["./config"] = "$HOME/.config/nvim",
@@ -233,469 +623,7 @@ return {
 ]]
     )
 
-    -- Set up 'zsh' module with new structure
-    setup_module(
-      "zsh",
-      [[
-return {
-  install = {
-    brew = "brew install zsh",
-  },
-  link = {
-    ["./zshrc"] = "$HOME/.zshrc",
-  }
-}
-]]
-    )
-
-    -- Set up 'apps/work' module with new structure
-    setup_module(
-      "apps/work",
-      [[
-return {
-  install = {
-    brew = "brew install work-app",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/work-app",
-  }
-}
-]]
-    )
-
-    -- Create 'personal' profile with exclusion
-    setup_profile(
-      "personal",
-      [[
-return {
-  modules = {
-    "*",
-    "!apps/work"
-  }
-}
-]]
-    )
-
-    -- Create config directories and files
-    pl_dir.makepath(pl_path.join(modules_dir, "neovim", "config"))
-    pl_file.write(pl_path.join(modules_dir, "neovim", "config", "init.vim"), "set number")
-    pl_file.write(pl_path.join(modules_dir, "zsh", "zshrc"), "export ZSH=~/.oh-my-zsh")
-    pl_dir.makepath(pl_path.join(modules_dir, "apps", "work", "config"))
-    pl_file.write(pl_path.join(modules_dir, "apps", "work", "config", "settings.json"), '{"key": "value"}')
-
-    -- Run dot.lua with 'personal' profile
-    assert.is_true(run_dot "personal")
-
-    -- Check if symlinks are created for neovim and zsh, but not for apps/work
-    local nvim_config = pl_path.join(home_dir, ".config", "nvim")
-    local zshrc = pl_path.join(home_dir, ".zshrc")
-    local work_app_config = pl_path.join(home_dir, ".config", "work-app")
-    assert.is_true(is_link(nvim_config), "Expected symlink for nvim_config")
-    assert.is_true(is_link(zshrc), "Expected symlink for zshrc")
-    assert.is_false(path_exists(work_app_config), "Did not expect symlink for work-app config")
-  end)
-
-  it("should replace existing configs in force mode", function()
-    -- Set up 'neovim' module with new structure
-    setup_module(
-      "neovim",
-      [[
-return {
-  install = {
-    brew = "brew install neovim",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/nvim",
-  }
-}
-]]
-    )
-
-    -- Create existing config
-    local nvim_config = pl_path.join(home_dir, ".config", "nvim")
-    pl_dir.makepath(pl_path.join(home_dir, ".config"))
-    pl_dir.makepath(nvim_config)
-    pl_file.write(pl_path.join(nvim_config, "init.vim"), "old config")
-
-    -- Create module config
-    pl_dir.makepath(pl_path.join(modules_dir, "neovim", "config"))
-    pl_file.write(pl_path.join(modules_dir, "neovim", "config", "init.vim"), "set number")
-
-    -- Run dot.lua with force flag
-    assert.is_true(run_dot "-f neovim")
-
-    -- Check if symlink is created
-    assert.is_true(is_link(nvim_config), "Expected symlink for nvim_config")
-
-    -- Check if backup exists
-    local backup_exists = false
-    for file in lfs.dir(pl_path.join(home_dir, ".config")) do
-      if file:match "^nvim.before%-dot" then
-        backup_exists = true
-        break
-      end
-    end
-    assert.is_true(backup_exists, "Backup file not found")
-  end)
-
-  it("should unlink configs with --unlink", function()
-    -- Set up 'neovim' module with new structure
-    setup_module(
-      "neovim",
-      [[
-return {
-  install = {
-    brew = "brew install neovim",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/nvim",
-  }
-}
-]]
-    )
-
-    -- Create module config
-    pl_dir.makepath(pl_path.join(modules_dir, "neovim", "config"))
-    pl_file.write(pl_path.join(modules_dir, "neovim", "config", "init.vim"), "set number")
-
-    -- Run dot.lua to install 'neovim'
-    assert.is_true(run_dot "neovim")
-
-    local nvim_config = pl_path.join(home_dir, ".config", "nvim")
-    assert.is_true(is_link(nvim_config), "Expected symlink for nvim_config")
-
-    -- Run dot.lua with --unlink option for 'neovim'
-    assert.is_true(run_dot "--unlink neovim")
-
-    -- Check if symlink is removed and config is copied
-    assert.is_false(is_link(nvim_config), "Expected symlink for nvim_config to be removed")
-    assert.is_true(path_exists(nvim_config), "Expected nvim_config to exist as a regular directory")
-
-    -- Verify the content of init.vim
-    local init_vim_path = pl_path.join(nvim_config, "init.vim")
-    assert.is_true(pl_path.isfile(init_vim_path), "init.vim does not exist after unlinking")
-    local content = pl_file.read(init_vim_path)
-    assert.are.equal("set number", content)
-  end)
-
-  it("should purge modules with --purge", function()
-    -- Set up 'neovim' module with new structure
-    setup_module(
-      "neovim",
-      [[
-return {
-  install = {
-    brew = "brew install neovim",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/nvim",
-  }
-}
-]]
-    )
-
-    -- Create module config
-    pl_dir.makepath(pl_path.join(modules_dir, "neovim", "config"))
-    pl_file.write(pl_path.join(modules_dir, "neovim", "config", "init.vim"), "set number")
-
-    -- Run dot.lua to install 'neovim'
-    assert.is_true(run_dot "neovim")
-
-    local nvim_config = pl_path.join(home_dir, ".config", "nvim")
-    assert.is_true(is_link(nvim_config), "Expected symlink for nvim_config")
-
-    -- Run dot.lua with --purge option for 'neovim'
-    assert.is_true(run_dot "--purge neovim")
-
-    -- Check if symlink is removed
-    assert.is_false(path_exists(nvim_config), "Expected nvim_config to be removed after purge")
-  end)
-
-  it("should run new hook system", function()
-    -- Set up 'dummy_app' module with new hooks using absolute paths
-    setup_module(
-      "dummy_app",
-      string.format(
-        [[
-return {
-  install = {
-    bash = "touch %s/.install_ran",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/dummy_app",
-  },
-  postinstall = "touch %s/.hooks_postinstall_ran",
-  postlink = "touch %s/.hooks_postlink_ran",
-}
-]],
-        home_dir,
-        home_dir,
-        home_dir
-      )
-    )
-
-    -- Create module config
-    pl_dir.makepath(pl_path.join(modules_dir, "dummy_app", "config"))
-    pl_file.write(pl_path.join(modules_dir, "dummy_app", "config", "config.txt"), "dummy config")
-
-    -- Run dot.lua to install 'dummy_app'
-    assert.is_true(run_dot "dummy_app")
-
-    -- Check if postinstall hook ran (should run because install happened)
-    local hook_postinstall = pl_path.join(home_dir, ".hooks_postinstall_ran")
-    assert.is_true(path_exists(hook_postinstall), "Post-install hook did not run")
-
-    -- Check if postlink hook ran (should run because link happened)
-    local hook_postlink = pl_path.join(home_dir, ".hooks_postlink_ran")
-    assert.is_true(path_exists(hook_postlink), "Post-link hook did not run")
-
-    -- Check if install command ran
-    local install_ran = pl_path.join(home_dir, ".install_ran")
-    assert.is_true(path_exists(install_ran), "Install command did not run")
-  end)
-
-  it("should handle multiple links in a module", function()
-    -- Set up 'multi_link' module with multiple links
-    setup_module(
-      "multi_link",
-      [[
-return {
-  link = {
-    ["./config/settings.json"] = "$HOME/settings.json",
-    ["./config/keybindings.json"] = "$HOME/keybindings.json",
-  }
-}
-]]
-    )
-
-    -- Create config files
-    pl_dir.makepath(pl_path.join(modules_dir, "multi_link", "config"))
-    pl_file.write(pl_path.join(modules_dir, "multi_link", "config", "settings.json"), [[{ "setting": "value" }]])
-    pl_file.write(pl_path.join(modules_dir, "multi_link", "config", "keybindings.json"), [[{ "key": "binding" }]])
-
-    -- Run dot.lua to install 'multi_link'
-    assert.is_true(run_dot "multi_link")
-
-    -- Check if symlinks are created
-    local settings = pl_path.join(home_dir, "settings.json")
-    local keybindings = pl_path.join(home_dir, "keybindings.json")
-    assert.is_true(is_link(settings), "Expected symlink for settings.json")
-    assert.is_true(is_link(keybindings), "Expected symlink for keybindings.json")
-  end)
-
-  it("should support directory linking", function()
-    -- Set up module that links entire directories
-    setup_module(
-      "dir_link",
-      [[
-return {
-  link = {
-    ["./zshrc.d"] = "$HOME/.zshrc.d",
-    ["./config"] = "$HOME/.config/myapp",
-  }
-}
-]]
-    )
-
-    -- Create directory structures
-    pl_dir.makepath(pl_path.join(modules_dir, "dir_link", "zshrc.d"))
-    pl_file.write(pl_path.join(modules_dir, "dir_link", "zshrc.d", "aliases.zsh"), "alias ll='ls -la'")
-    pl_file.write(pl_path.join(modules_dir, "dir_link", "zshrc.d", "exports.zsh"), "export EDITOR=nvim")
-    
-    pl_dir.makepath(pl_path.join(modules_dir, "dir_link", "config"))
-    pl_file.write(pl_path.join(modules_dir, "dir_link", "config", "config.json"), '{"theme": "dark"}')
-
-    -- Run dot.lua to install 'dir_link'
-    assert.is_true(run_dot "dir_link")
-
-    -- Check if directory symlinks are created
-    local zshrc_d = pl_path.join(home_dir, ".zshrc.d")
-    local config_dir = pl_path.join(home_dir, ".config", "myapp")
-    assert.is_true(is_link(zshrc_d), "Expected symlink for .zshrc.d directory")
-    assert.is_true(is_link(config_dir), "Expected symlink for config directory")
-  end)
-
-  it("should display help message with -h option", function()
-    -- Run dot.lua with -h option
-    local cmd = string.format("cd %q && HOME=%q lua %q -h", dotfiles_dir, home_dir, dot_executable)
-    local handle = io.popen(cmd)
-    local output = handle:read("*a")
-    handle:close()
-
-    -- Check if the output contains the expected start of the help message
-    local expected_start = "Usage: dot"
-    assert.is_true(output:find(expected_start, 1, true) ~= nil, "Help message not displayed correctly")
-  end)
-
-  it("should handle OS-specific modules", function()
-    -- Set up a module that only works on the current OS
-    local current_os = io.popen("uname"):read("*l") -- Get the current OS
-    local is_macos = current_os == "Darwin"
-    local is_linux = current_os == "Linux"
-    
-    -- Set up 'os_specific' module for the current OS
-    setup_module(
-      "os_specific_current",
-      [[
-return {
-  os = { "]] .. (is_macos and "darwin" or "linux") .. [[" },
-  link = {
-    ["./config"] = "$HOME/.config/os_specific_current",
-  }
-}
-]]
-    )
-    
-    -- Set up a module for the other OS
-    setup_module(
-      "os_specific_other",
-      [[
-return {
-  os = { "]] .. (is_macos and "linux" or "darwin") .. [[" },
-  link = {
-    ["./config"] = "$HOME/.config/os_specific_other",
-  }
-}
-]]
-    )
-    
-    -- Create config directories and files
-    pl_dir.makepath(pl_path.join(modules_dir, "os_specific_current", "config"))
-    pl_file.write(pl_path.join(modules_dir, "os_specific_current", "config", "config.txt"), "current os config")
-    
-    pl_dir.makepath(pl_path.join(modules_dir, "os_specific_other", "config"))
-    pl_file.write(pl_path.join(modules_dir, "os_specific_other", "config", "config.txt"), "other os config")
-    
-    -- Run dot.lua without arguments to install all modules
-    assert.is_true(run_dot())
-    
-    -- Check if the current OS module is installed and the other OS module is skipped
-    local current_config = pl_path.join(home_dir, ".config", "os_specific_current")
-    local other_config = pl_path.join(home_dir, ".config", "os_specific_other")
-    
-    assert.is_true(is_link(current_config), "Expected symlink for current OS module")
-    assert.is_false(path_exists(other_config), "Did not expect symlink for other OS module")
-  end)
-
-  it("should support fuzzy module matching", function()
-    -- Set up nested module structure
-    setup_module(
-      "ricing/hyprland",
-      [[
-return {
-  install = {
-    apt = "sudo apt install -y hyprland",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/hypr",
-  }
-}
-]]
-    )
-
-    -- Create config
-    pl_dir.makepath(pl_path.join(modules_dir, "ricing", "hyprland", "config"))
-    pl_file.write(pl_path.join(modules_dir, "ricing", "hyprland", "config", "hyprland.conf"), "# Hyprland config")
-
-    -- Test fuzzy matching: 'hypr' should match 'ricing/hyprland'
-    assert.is_true(run_dot "hypr")
-
-    -- Check if symlink is created
-    local hypr_config = pl_path.join(home_dir, ".config", "hypr")
-    assert.is_true(is_link(hypr_config), "Expected symlink for hypr config via fuzzy match")
-  end)
-
-  it("should handle command detection for install", function()
-    -- Set up module with multiple install options
-    setup_module(
-      "test_detection",
-      [[
-return {
-  install = {
-    nonexistent_cmd = "nonexistent_cmd install test",
-    bash = "echo 'bash install worked' > ]] .. home_dir .. [[/install_result.txt",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/test_detection",
-  }
-}
-]]
-    )
-
-    -- Create config
-    pl_dir.makepath(pl_path.join(modules_dir, "test_detection", "config"))
-    pl_file.write(pl_path.join(modules_dir, "test_detection", "config", "test.conf"), "test config")
-
-    -- Run dot.lua - should use bash since nonexistent_cmd doesn't exist
-    assert.is_true(run_dot "test_detection")
-
-    -- Check if bash command was executed
-    local install_result = pl_path.join(home_dir, "install_result.txt")
-    assert.is_true(path_exists(install_result), "Expected bash install command to run")
-    
-    local content = pl_file.read(install_result)
-    assert.are.equal("bash install worked", content:match("^%s*(.-)%s*$"))
-  end)
-
-  it("should run postinstall only when install happens", function()
-    -- Set up module with install that does nothing the second time
-    setup_module(
-      "install_once",
-      string.format(
-        [[
-return {
-  install = {
-    bash = "test ! -f %s/.already_installed && touch %s/.already_installed || exit 0",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/install_once",
-  },
-  postinstall = "touch %s/.postinstall_ran",
-}
-]],
-        home_dir, home_dir, home_dir
-      )
-    )
-
-    -- Create config
-    pl_dir.makepath(pl_path.join(modules_dir, "install_once", "config"))
-    pl_file.write(pl_path.join(modules_dir, "install_once", "config", "test.conf"), "test config")
-
-    -- First run - should run postinstall
-    assert.is_true(run_dot "install_once")
-    
-    local postinstall_marker = pl_path.join(home_dir, ".postinstall_ran")
-    assert.is_true(path_exists(postinstall_marker), "Expected postinstall to run on first install")
-
-    -- Remove postinstall marker
-    os.remove(postinstall_marker)
-
-    -- Second run - should NOT run postinstall since install already happened
-    assert.is_true(run_dot "install_once")
-    assert.is_false(path_exists(postinstall_marker), "Did not expect postinstall to run on second install")
-  end)
-
-  it("should save the last used profile", function()
-    -- Set up 'neovim' module with new structure
-    setup_module(
-      "neovim",
-      [[
-return {
-  install = {
-    brew = "brew install neovim",
-  },
-  link = {
-    ["./config"] = "$HOME/.config/nvim",
-  }
-}
-]]
-    )
-
-    -- Create config directories and files for 'neovim'
-    pl_dir.makepath(pl_path.join(modules_dir, "neovim", "config"))
-    pl_file.write(pl_path.join(modules_dir, "neovim", "config", "init.vim"), "set number")
-
-    -- Set up a dummy profile
+    -- Create test profile
     setup_profile(
       "test_profile",
       [[
@@ -707,14 +635,26 @@ return {
 ]]
     )
 
-    -- Run dot.lua with the 'test_profile' profile
+    -- Create config
+    pl_dir.makepath(pl_path.join(modules_dir, "neovim", "config"))
+    pl_file.write(pl_path.join(modules_dir, "neovim", "config", "init.vim"), "set number")
+
+    -- Run with profile to save it
     assert.is_true(run_dot "test_profile")
 
-    -- Check if the .dot file contains the correct profile name
-    local dot_file_path = pl_path.join(dotfiles_dir, ".dot")
-    assert.is_true(pl_path.isfile(dot_file_path), ".dot file not found")
+    -- Clear command log
+    pl_file.write(command_log_file, "")
 
+    -- Run without arguments - should use saved profile
+    assert.is_true(run_dot())
+
+    -- Check that the profile was used (apt command executed again)
+    assert.is_true(was_command_executed("apt"), "apt should have been executed using saved profile")
+
+    -- Check that .dot file was created with correct profile
+    local dot_file_path = pl_path.join(dotfiles_dir, ".dot")
+    assert.is_true(pl_path.isfile(dot_file_path), ".dot file should exist")
     local content = pl_file.read(dot_file_path)
-    assert.are.equal("test_profile", content:match("^%s*(.-)%s*$"), "Profile name in .dot file is incorrect")
+    assert.are.equal("test_profile", content:match("^%s*(.-)%s*$"), "Profile name should be saved correctly")
   end)
 end)

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -33,8 +33,8 @@ describe("dot.lua", function()
   local function setup_module(name, content)
     local module_dir = pl_path.join(modules_dir, name)
     pl_dir.makepath(module_dir)
-    local init_lua = pl_path.join(module_dir, "init.lua")
-    pl_file.write(init_lua, content)
+    local dot_lua = pl_path.join(module_dir, "dot.lua")
+    pl_file.write(dot_lua, content)
   end
 
   -- Function to set up a profile with given name and content

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -721,9 +721,7 @@ return {
       "work",
       [[
 {
-  modules = {
-    "neovim"
-  }
+  "neovim"
 }
 ]]
     )
@@ -771,9 +769,7 @@ return {
       "test_profile",
       [[
 {
-  modules = {
-    "neovim"
-  }
+  "neovim"
 }
 ]]
     )
@@ -1059,9 +1055,7 @@ return {
       "test_profile",
       [[
 {
-  modules = {
-    "neovim"
-  }
+  "neovim"
 }
 ]]
     )

--- a/spec/dot_spec.lua
+++ b/spec/dot_spec.lua
@@ -21,7 +21,7 @@ describe("dot.lua", function()
   -- Function to check if a path is a symbolic link
   local function is_link(path)
     local attr = lfs.symlinkattributes(path)
-    return attr and attr.mode == "link"
+    return attr and attr.mode == "link" or false
   end
 
   -- Function to create a fake command that logs when it's called


### PR DESCRIPTION
- **Universal package manager support** - the tool no longer has built-in support for specific package managers (homebrew, apt, etc.). Instead, users now provide the actual bash commands they want to run, allowing support for ANY package manager or installation method
- **Module file renamed** - `init.lua` files must now be renamed to `dot.lua` in each module directory
- **Profile file renamed** - `profiles.lua` replaces the old profile system
- **New installation syntax** - instead of specifying package managers, users now write the actual installation commands (e.g., brew install package instead of just package)
- **New module structure** - modules now use a `dot.lua` file instead of `init.lua` for configuration
- **Profile configuration format** - profiles now use a `profiles.lua` file with a different structure
- **Hook names changed** - postinstall and postlink hooks replace the old hook system
- **Enhanced error handling and output filtering** - improved command execution with better error reporting
- **Comprehensive test suite overhaul** - completely refactored test environment with 42 passing tests
- **Version bump to 1.0.0** - marking these breaking changes as a major release
- **Removed deprecated features** - eliminated mock/testing options and Brew-specific utilities