### PR TITLE
Fix script printing instead of saving

### DIFF
--- a/dot.lua
+++ b/dot.lua
@@ -173,6 +173,7 @@ local function execute(cmd)
     and not cmd:match "^find "
     and not cmd:match "find ."
     and not cmd:match "^readlink "
+    and not cmd:match "curl "
   then
     print(output)
   end


### PR DESCRIPTION
Stop `curl` command output from being printed to the console.

The `execute` function was printing the content of the downloaded script when `curl` was used, instead of silently saving it to the specified location.

---
<a href="https://cursor.com/background-agent?bcId=bc-75d15569-2935-4a71-9946-af4e05f4d43f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75d15569-2935-4a71-9946-af4e05f4d43f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>