### PR TITLE
Install exo components with error handling

### DIFF
--- a/cmd/dot/main.go
+++ b/cmd/dot/main.go
@@ -234,7 +234,13 @@ func (a *App) Run(args []string) error {
 	// Check for unmatched fuzzy search terms and report errors
 	var unmatchedTerms []string
 	if fuzzySearch != "" {
-		result, err := profileManager.GetActiveComponentsWithSearchResult(activeProfiles, fuzzySearch)
+		// If doing fuzzy search and no specific profiles are requested, search across all profiles
+		searchProfiles := activeProfiles
+		if len(activeProfiles) == 0 {
+			searchProfiles = profileManager.ListProfiles()
+		}
+		
+		result, err := profileManager.GetActiveComponentsWithSearchResult(searchProfiles, fuzzySearch)
 		if err != nil {
 			return err
 		}
@@ -357,10 +363,17 @@ func (a *App) Run(args []string) error {
 		// Use regular installation for verbose mode
 		var results []component.InstallResult
 		var err error
+		
+		// If doing fuzzy search and no specific profiles are requested, search across all profiles
+		installProfiles := activeProfiles
+		if fuzzySearch != "" && len(activeProfiles) == 0 {
+			installProfiles = profileManager.ListProfiles()
+		}
+		
 		if profilesFromUser {
-			results, err = componentManager.InstallComponents(activeProfiles, fuzzySearch, a.ForceInstall)
+			results, err = componentManager.InstallComponents(installProfiles, fuzzySearch, a.ForceInstall)
 		} else {
-			results, err = componentManager.InstallComponentsWithoutSaving(activeProfiles, fuzzySearch, a.ForceInstall)
+			results, err = componentManager.InstallComponentsWithoutSaving(installProfiles, fuzzySearch, a.ForceInstall)
 		}
 		if err != nil {
 			return err
@@ -373,10 +386,17 @@ func (a *App) Run(args []string) error {
 
 		var results []component.InstallResult
 		var err error
+		
+		// If doing fuzzy search and no specific profiles are requested, search across all profiles
+		installProfiles := activeProfiles
+		if fuzzySearch != "" && len(activeProfiles) == 0 {
+			installProfiles = profileManager.ListProfiles()
+		}
+		
 		if profilesFromUser {
-			results, err = componentManager.InstallComponentsWithProgress(activeProfiles, fuzzySearch, a.ForceInstall, progressManager)
+			results, err = componentManager.InstallComponentsWithProgress(installProfiles, fuzzySearch, a.ForceInstall, progressManager)
 		} else {
-			results, err = componentManager.InstallComponentsWithProgressWithoutSaving(activeProfiles, fuzzySearch, a.ForceInstall, progressManager)
+			results, err = componentManager.InstallComponentsWithProgressWithoutSaving(installProfiles, fuzzySearch, a.ForceInstall, progressManager)
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
Fix fuzzy search to find components across all profiles when no specific profiles are provided.

Previously, `dot <component_name>` would only search within the default active profile (`*`), failing to locate components defined in other profiles (e.g., `ai-node.exo`). This change ensures that fuzzy searches without explicit profile arguments correctly scan all available profiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5b04878-3418-45de-bb6f-baec787b82ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5b04878-3418-45de-bb6f-baec787b82ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

