### PR TITLE
Persist profiles before install; save even if installs fail

### DIFF
--- a/cmd/dot/main.go
+++ b/cmd/dot/main.go
@@ -335,6 +335,18 @@ func (a *App) Run(args []string) error {
 		return nil
 	}
 
+	// Persist active profiles early when provided by user (ensures they are saved even if installs fail hard)
+	if !a.DryRun && profilesFromUser {
+		stateManager, err := state.NewManager()
+		if err != nil {
+			return fmt.Errorf("failed to create state manager: %w", err)
+		}
+		stateManager.SetActiveProfiles(activeProfiles)
+		if err := stateManager.Save(); err != nil {
+			return fmt.Errorf("failed to save state: %w", err)
+		}
+	}
+
 	// Main install operation
 	if a.Verbose {
 		fmt.Printf("🚀 Starting %s operation...\n", "installation")


### PR DESCRIPTION
## Summary
- Persist user-specified active profiles to state before starting installation, ensuring `dot <profile>` is saved even if installs fail or the run exits early
- Add regression test verifying profiles are saved when an install command fails (e.g., `sh: false`)

## Why
- Users expect their selected profiles to be remembered immediately; previously profiles were saved late in the run. If anything aborted before saving, the selection could be lost.

## Details
- In App.Run, when profiles are provided by the user and not in dry-run, we persist them to the state file prior to installation
- Kept existing post-install saves for consistency; the pre-save is additive and safe
- New unit test: TestProfileSavedEvenIfInstallFails

## Test plan
- go test ./... passes
- Unit test explicitly checks that the state’s ActiveProfiles includes the chosen profile even if a component install fails

🤖 Generated with [opencode](https://opencode.ai)